### PR TITLE
Potential fix for code scanning alert no. 2: Shell command built from environment values

### DIFF
--- a/scripts/package.js
+++ b/scripts/package.js
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const fsp = fs.promises;
 const path = require('path');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 
 const root = process.cwd();
 const distRoot = path.join(root, 'dist');
@@ -68,11 +68,11 @@ async function main(){
   // Create zip
   const zipPath = path.join(distRoot, `${themeSlug}.zip`);
   try {
-    execSync(`cd ${distRoot} && zip -rq ${themeSlug}.zip ${themeSlug}`);
+    execFileSync('zip', ['-rq', `${themeSlug}.zip`, themeSlug], { cwd: distRoot });
     console.log(`Created ${zipPath}`);
   } catch (e) {
     console.warn('zip not available, creating tar.gz instead');
-    execSync(`cd ${distRoot} && tar -czf ${themeSlug}.tar.gz ${themeSlug}`);
+    execFileSync('tar', ['-czf', `${themeSlug}.tar.gz`, themeSlug], { cwd: distRoot });
     console.log(`Created ${path.join(distRoot, themeSlug + '.tar.gz')}`);
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/barning/2025child/security/code-scanning/2](https://github.com/barning/2025child/security/code-scanning/2)

In general, the fix is to stop embedding `distRoot` (and other dynamic values) directly into a shell command string executed via `execSync`, and instead (a) change directory using Node APIs, and (b) invoke `zip`/`tar` via `execFileSync` or `spawnSync` with arguments passed as an array. This avoids shell parsing of the path and prevents special characters from altering the command.

Concretely for this file, the safest minimal-change fix is:

- Import `execFileSync` from `child_process`.
- Replace the `execSync` calls that do `cd ${distRoot} && zip ...` / `cd ${distRoot} && tar ...` with `execFileSync` calls:
  - Set `cwd: distRoot` in the options instead of using `cd` in the command.
  - Pass `zip`/`tar` arguments as separate array elements, including the archive filename and `themeSlug`.
- Keep logging and behavior the same, only altering how the commands are invoked.

Changes needed:

- In `scripts/package.js`, update the import on line 5 to also include `execFileSync`.
- Replace lines 71–76 with equivalent logic using `execFileSync('zip', [...], { cwd: distRoot })` and `execFileSync('tar', [...], { cwd: distRoot })`.

No new helper methods are strictly required; we just adjust the existing calls.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
