### PR TITLE
Add responsive-navigation block and register it for the theme

### DIFF
--- a/blocks/index.js
+++ b/blocks/index.js
@@ -5,3 +5,5 @@ import './magic-cards';
 import './media-recommendation'; // Ensure consistency with other blocks by registering here
 import './videogame-recommendation';
 import './pixelfed-feed';
+
+import './responsive-navigation';

--- a/blocks/responsive-navigation/block.json
+++ b/blocks/responsive-navigation/block.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": 3,
+  "name": "child/responsive-navigation",
+  "title": "Responsive Navigation",
+  "category": "widgets",
+  "icon": "menu",
+  "description": "Accessible, CSS-only navigation wrapper with a semantic burger disclosure on smaller screens.",
+  "attributes": {
+    "ariaLabel": {
+      "type": "string",
+      "default": "Primary navigation"
+    },
+    "toggleLabel": {
+      "type": "string",
+      "default": "Menu"
+    }
+  },
+  "supports": {
+    "html": false,
+    "anchor": true
+  },
+  "editorScript": "file:./index.js",
+  "editorStyle": "file:./editor.css",
+  "style": "file:./style.css"
+}

--- a/blocks/responsive-navigation/editor.css
+++ b/blocks/responsive-navigation/editor.css
@@ -1,0 +1,8 @@
+.wp-block-child-responsive-navigation {
+	outline: 1px dashed #d0d7de;
+	padding: 0.75rem;
+}
+
+.wp-block-child-responsive-navigation .components-notice {
+	margin-bottom: 0.75rem;
+}

--- a/blocks/responsive-navigation/index.js
+++ b/blocks/responsive-navigation/index.js
@@ -1,0 +1,90 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import {
+	InspectorControls,
+	InnerBlocks,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import { PanelBody, TextControl, Notice } from '@wordpress/components';
+import metadata from './block.json';
+import './editor.css';
+import './style.css';
+
+const ALLOWED_BLOCKS = [ 'core/list' ];
+
+const TEMPLATE = [
+	[
+		'core/list',
+		{
+			className: 'child-responsive-navigation__list',
+			ordered: false,
+		},
+		[
+			[ 'core/list-item', { content: '<a href="#">Home</a>' } ],
+			[ 'core/list-item', { content: '<a href="#">About</a>' } ],
+			[ 'core/list-item', { content: '<a href="#">Contact</a>' } ],
+		],
+	],
+];
+
+function Edit( { attributes, setAttributes } ) {
+	const { ariaLabel, toggleLabel } = attributes;
+	const blockProps = useBlockProps();
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Navigation settings', 'child' ) }>
+					<TextControl
+						label={ __( 'Navigation aria-label', 'child' ) }
+						value={ ariaLabel }
+						onChange={ ( value ) => setAttributes( { ariaLabel: value } ) }
+					/>
+					<TextControl
+						label={ __( 'Burger label', 'child' ) }
+						value={ toggleLabel }
+						onChange={ ( value ) => setAttributes( { toggleLabel: value } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<nav { ...blockProps } aria-label={ ariaLabel }>
+				<Notice status="info" isDismissible={ false }>
+					{ __(
+						'This block is CSS-only on the frontend: links are shown inline on wide screens and in a burger disclosure on narrow screens.',
+						'child'
+					) }
+				</Notice>
+				<InnerBlocks
+					allowedBlocks={ ALLOWED_BLOCKS }
+					template={ TEMPLATE }
+					templateLock={ false }
+				/>
+			</nav>
+		</>
+	);
+}
+
+function Save( { attributes } ) {
+	const { ariaLabel, toggleLabel } = attributes;
+	const blockProps = useBlockProps.save();
+
+	return (
+		<nav { ...blockProps } aria-label={ ariaLabel }>
+			<div className="child-responsive-navigation__inline" aria-hidden="true">
+				<InnerBlocks.Content />
+			</div>
+			<details className="child-responsive-navigation__disclosure">
+				<summary>{ `☰ ${ toggleLabel }` }</summary>
+				<div className="child-responsive-navigation__panel">
+					<InnerBlocks.Content />
+				</div>
+			</details>
+		</nav>
+	);
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: Save,
+} );

--- a/blocks/responsive-navigation/style.css
+++ b/blocks/responsive-navigation/style.css
@@ -1,0 +1,45 @@
+.wp-block-child-responsive-navigation {
+	display: block;
+}
+
+.wp-block-child-responsive-navigation .child-responsive-navigation__inline .wp-block-list,
+.wp-block-child-responsive-navigation .child-responsive-navigation__panel .wp-block-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.wp-block-child-responsive-navigation .child-responsive-navigation__inline .wp-block-list {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.75rem;
+	align-items: center;
+}
+
+.wp-block-child-responsive-navigation .child-responsive-navigation__inline .wp-block-list li,
+.wp-block-child-responsive-navigation .child-responsive-navigation__panel .wp-block-list li {
+	margin: 0;
+}
+
+.wp-block-child-responsive-navigation .child-responsive-navigation__disclosure {
+	display: none;
+}
+
+@media (max-width: 48rem) {
+	.wp-block-child-responsive-navigation .child-responsive-navigation__inline {
+		display: none;
+	}
+
+	.wp-block-child-responsive-navigation .child-responsive-navigation__disclosure {
+		display: block;
+	}
+
+	.wp-block-child-responsive-navigation .child-responsive-navigation__disclosure summary {
+		cursor: pointer;
+		list-style: none;
+	}
+
+	.wp-block-child-responsive-navigation .child-responsive-navigation__panel {
+		margin-top: 0.75rem;
+	}
+}

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -159,3 +159,14 @@ function child_localize_block_editor_script( string $block_name, string $object_
 		wp_localize_script( $handle, $object_name, $data );
 	}
 }
+
+
+/**
+ * Register static blocks that do not require frontend PHP render callbacks.
+ */
+function child_register_static_blocks(): void {
+	$theme_dir = get_stylesheet_directory();
+
+	register_block_type( $theme_dir . '/build/responsive-navigation' );
+}
+add_action( 'init', 'child_register_static_blocks' );


### PR DESCRIPTION
### Motivation

- Provide an accessible, CSS-only responsive navigation block to offer a semantic burger disclosure on narrow screens and inline links on wide screens.
- Ensure the new block is included in the theme's block list and available in the editor.

### Description

- Added a new block at `blocks/responsive-navigation` with `block.json`, editor script `index.js`, editor styles `editor.css`, and frontend styles `style.css` to implement a CSS-only responsive navigation using a `details`/`summary` disclosure and `InnerBlocks` for a `core/list` menu template.
- Wired the block into the theme by importing `./responsive-navigation` in `blocks/index.js` so it is registered with the other blocks.
- Added `child_register_static_blocks()` in `inc/blocks.php` to call `register_block_type( $theme_dir . '/build/responsive-navigation' )` and hooked it into `init` so the static block is registered for the frontend.
- The editor UI exposes two attributes `ariaLabel` and `toggleLabel`, shows an informational `Notice`, and restricts allowed inner blocks to `core/list` with a default template.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c241d68c1c8325ae2f714a32c1d576)