### PR TITLE
Add Activity Embed Gutenberg block for Garmin and Strava links

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A production-focused child theme for **Twenty Twenty-Five** that keeps customiza
 
 ## Dynamic Blocks Registered
 
+- `child/activity-embed`
 - `child/book-rating`
 - `child/magic-cards`
 - `child/media-recommendation`
@@ -80,3 +81,19 @@ npm run dist
 - Keeps child-theme overrides intentionally minimal.
 - Uses consistent prefixed function names (`child_*`) to avoid collisions.
 - Consolidates duplicated registration/enqueue logic to simplify future parent-theme updates.
+
+
+## Activity Embed Block
+
+`Activity Embed` (`child/activity-embed`) accepts one URL attribute and supports:
+
+- `https://connect.garmin.com/`
+- `https://www.strava.com/`
+
+It validates the URL server-side, detects the provider, and renders either oEmbed (for Strava when available) or a provider iframe fallback.
+
+Example block markup in post content:
+
+```html
+<!-- wp:child/activity-embed {"url":"https://www.strava.com/activities/1234567890"} /-->
+```

--- a/blocks/activity-embed/block.json
+++ b/blocks/activity-embed/block.json
@@ -1,0 +1,20 @@
+{
+  "apiVersion": 3,
+  "name": "child/activity-embed",
+  "title": "Activity Embed",
+  "category": "embed",
+  "icon": "share",
+  "description": "Embed Garmin Connect or Strava activity previews.",
+  "attributes": {
+    "url": {
+      "type": "string",
+      "default": ""
+    }
+  },
+  "supports": {
+    "html": false
+  },
+  "editorScript": "file:./index.js",
+  "editorStyle": "file:./editor.css",
+  "style": "file:./style.css"
+}

--- a/blocks/activity-embed/editor.css
+++ b/blocks/activity-embed/editor.css
@@ -1,0 +1,5 @@
+@import './style.css';
+
+.wp-block-child-activity-embed .components-placeholder {
+	margin-bottom: 1rem;
+}

--- a/blocks/activity-embed/index.js
+++ b/blocks/activity-embed/index.js
@@ -1,0 +1,49 @@
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps, InspectorControls, URLInput } from '@wordpress/block-editor';
+import { PanelBody, TextControl, Placeholder } from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
+import metadata from './block.json';
+import './editor.css';
+import './style.css';
+
+function Edit( { attributes, setAttributes } ) {
+	const { url = '' } = attributes;
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Activity Embed Settings', 'child' ) } initialOpen>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Activity URL', 'child' ) }
+						value={ url }
+						onChange={ ( value ) => setAttributes( { url: value } ) }
+						placeholder={ __( 'Paste Garmin or Strava activity link', 'child' ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<div { ...useBlockProps() }>
+				<Placeholder
+					label={ __( 'Activity Embed', 'child' ) }
+					instructions={ __( 'Paste Garmin or Strava activity link', 'child' ) }
+				>
+					<URLInput
+						value={ url }
+						onChange={ ( value ) => setAttributes( { url: value } ) }
+						placeholder={ __( 'Paste Garmin or Strava activity link', 'child' ) }
+					/>
+				</Placeholder>
+
+				{ url ? <ServerSideRender block={ metadata.name } attributes={ attributes } /> : null }
+			</div>
+		</>
+	);
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/blocks/activity-embed/render.php
+++ b/blocks/activity-embed/render.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Server-side render for Activity Embed block.
+ */
+
+/**
+ * Extract activity id from a URL path.
+ *
+ * @param string $path URL path.
+ * @return string
+ */
+function child_activity_embed_extract_id( string $path ): string {
+	$patterns = [
+		'#/activities/(\d+)#',
+		'#/activity/(\d+)#',
+	];
+
+	foreach ( $patterns as $pattern ) {
+		if ( preg_match( $pattern, $path, $matches ) ) {
+			return $matches[1];
+		}
+	}
+
+	return '';
+}
+
+/**
+ * Detect supported provider.
+ *
+ * @param string $host Parsed URL host.
+ * @return string
+ */
+function child_activity_embed_detect_provider( string $host ): string {
+	$host = strtolower( $host );
+	$host = preg_replace( '/^www\./', '', $host );
+
+	if ( 'connect.garmin.com' === $host ) {
+		return 'garmin';
+	}
+
+	if ( 'strava.com' === $host || 'www.strava.com' === $host ) {
+		return 'strava';
+	}
+
+	return '';
+}
+
+return function( $attributes ) {
+	$wrapper_attributes = get_block_wrapper_attributes();
+	$url                = isset( $attributes['url'] ) ? esc_url_raw( trim( (string) $attributes['url'] ) ) : '';
+
+	if ( '' === $url ) {
+		return sprintf(
+			'<div %1$s><p class="child-activity-embed__notice">%2$s</p></div>',
+			$wrapper_attributes,
+			esc_html__( 'Paste Garmin or Strava activity link.', 'child' )
+		);
+	}
+
+	if ( ! wp_http_validate_url( $url ) ) {
+		return sprintf(
+			'<div %1$s><p class="child-activity-embed__notice">%2$s</p></div>',
+			$wrapper_attributes,
+			esc_html__( 'Invalid URL. Please paste a valid Garmin or Strava activity link.', 'child' )
+		);
+	}
+
+	$host     = (string) wp_parse_url( $url, PHP_URL_HOST );
+	$path     = (string) wp_parse_url( $url, PHP_URL_PATH );
+	$provider = child_activity_embed_detect_provider( $host );
+
+	if ( '' === $provider ) {
+		return sprintf(
+			'<div %1$s><p class="child-activity-embed__notice">%2$s</p></div>',
+			$wrapper_attributes,
+			esc_html__( 'Unsupported provider. Please use a Garmin Connect or Strava activity URL.', 'child' )
+		);
+	}
+
+	$embed_markup = '';
+
+	if ( 'strava' === $provider ) {
+		$embed_markup = wp_oembed_get(
+			$url,
+			[
+				'width' => 1200,
+			]
+		);
+
+		if ( false === $embed_markup ) {
+			$activity_id = child_activity_embed_extract_id( $path );
+			if ( '' !== $activity_id ) {
+				$iframe_url   = 'https://www.strava.com/activities/' . rawurlencode( $activity_id ) . '/embed';
+				$embed_markup = sprintf(
+					'<div class="child-activity-embed__iframe-wrap"><iframe src="%1$s" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen title="%2$s"></iframe></div>',
+					esc_url( $iframe_url ),
+					esc_attr__( 'Strava activity preview', 'child' )
+				);
+			}
+		}
+	}
+
+	if ( 'garmin' === $provider ) {
+		$activity_id = child_activity_embed_extract_id( $path );
+		if ( '' !== $activity_id ) {
+			$iframe_url   = 'https://connect.garmin.com/modern/activity/embed/' . rawurlencode( $activity_id );
+			$embed_markup = sprintf(
+				'<div class="child-activity-embed__iframe-wrap"><iframe src="%1$s" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen title="%2$s"></iframe></div>',
+				esc_url( $iframe_url ),
+				esc_attr__( 'Garmin activity preview', 'child' )
+			);
+		}
+	}
+
+	if ( '' === $embed_markup ) {
+		return sprintf(
+			'<div %1$s><p class="child-activity-embed__notice">%2$s</p></div>',
+			$wrapper_attributes,
+			esc_html__( 'Could not generate an embed for this activity URL. Please check that the activity is public.', 'child' )
+		);
+	}
+
+	return sprintf(
+		'<div %1$s><div class="child-activity-embed__content child-activity-embed__content--%2$s">%3$s</div></div>',
+		$wrapper_attributes,
+		esc_attr( $provider ),
+		$embed_markup
+	);
+};

--- a/blocks/activity-embed/style.css
+++ b/blocks/activity-embed/style.css
@@ -1,0 +1,36 @@
+.wp-block-child-activity-embed {
+	margin: 1.5rem 0;
+}
+
+.child-activity-embed__content {
+	position: relative;
+	width: 100%;
+	max-width: 100%;
+	overflow: hidden;
+	border-radius: 12px;
+}
+
+.child-activity-embed__content iframe,
+.child-activity-embed__content embed,
+.child-activity-embed__content object {
+	display: block;
+	width: 100%;
+	max-width: 100%;
+	border: 0;
+}
+
+.child-activity-embed__iframe-wrap {
+	aspect-ratio: 16 / 9;
+}
+
+.child-activity-embed__iframe-wrap iframe {
+	height: 100%;
+}
+
+.child-activity-embed__notice {
+	padding: 0.9rem 1rem;
+	border: 1px dashed color-mix(in srgb, currentColor 20%, transparent);
+	border-radius: 10px;
+	font-size: 0.95rem;
+	color: color-mix(in srgb, currentColor 75%, transparent);
+}

--- a/blocks/index.js
+++ b/blocks/index.js
@@ -1,3 +1,4 @@
+import './activity-embed';
 import './popular-posts';
 import './visual-link-preview';
 import './book-rating';

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -12,6 +12,10 @@
  */
 function child_get_dynamic_blocks(): array {
 	return [
+		'activity-embed'           => [
+			'block_name'  => 'child/activity-embed',
+			'render_file' => 'blocks/activity-embed/render.php',
+		],
 		'book-rating'              => [
 			'block_name'  => 'child/book-rating',
 			'render_file' => 'blocks/book-rating/render.php',


### PR DESCRIPTION
### Motivation
- Provide editors with a simple block to paste Garmin or Strava activity links and get an embedded, responsive preview inside posts and the Gutenberg editor.
- Support trusted providers (`connect.garmin.com` and `www.strava.com`) while validating and sanitizing input to avoid outputting arbitrary markup.

### Description
- Added a dynamic block `child/activity-embed` with `block.json` metadata and a single `url` attribute, editor script, editor style, and frontend style (`blocks/activity-embed/*`).
- Implemented editor UX using `InspectorControls` + a sidebar `TextControl`, inline `URLInput` placeholder text `"Paste Garmin or Strava activity link"`, and live preview via `ServerSideRender` (`blocks/activity-embed/index.js`).
- Implemented a PHP server-side render callback that sanitizes/validates the URL (`esc_url_raw`, `wp_http_validate_url`), detects provider by host, attempts `wp_oembed_get` for Strava, falls back to provider iframe embeds (Strava and Garmin), extracts numeric activity IDs via regex, and renders user-friendly fallback notices (`blocks/activity-embed/render.php`).
- Added minimal responsive styles that inherit theme defaults and avoid layout breaks (full-width media, `aspect-ratio` iframe wrapper, compact notices) plus an editor stylesheet; registered the block in the theme registry (`inc/blocks.php`) and imported it in the block entry (`blocks/index.js`); documented usage in `README.md`.

### Testing
- Ran `npm run build` and the build completed successfully (webpack compiled without errors).
- Ran `php -l blocks/activity-embed/render.php` and reported "No syntax errors detected".

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c27da8fc348325aa65408f5c0ace88)