### PR TITLE
Add Open Stories admin authoring and JSON feed endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A production-focused child theme for **Twenty Twenty-Five** that keeps customiza
 - `child/book-rating`
 - `child/magic-cards`
 - `child/media-recommendation`
+- `child/open-stories-viewer`
 - `child/pixelfed-feed`
 - `child/popular-posts`
 - `child/videogame-recommendation`
@@ -59,6 +60,7 @@ Each block:
 - Adds an **Open Stories** custom post type in wp-admin for authoring story items.
 - Adds an **Open Stories** settings page under **Settings → Open Stories** for feed metadata defaults.
 - Publishes an Open Stories-compatible JSON feed at `/open-stories.json`.
+- Includes a Gutenberg **Open Stories Viewer** block (`child/open-stories-viewer`) that renders the `open-stories-element` web component for playback.
 
 ## Notes Custom Post Type
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Each block:
 - API key lookup order: option `child_rawg_api_key`, then `RAWG_API_KEY` constant fallback.
 - Editor AJAX endpoint: `wp_ajax_child_rawg_search`.
 
+### Open Stories
+- Adds an **Open Stories** custom post type in wp-admin for authoring story items.
+- Adds an **Open Stories** settings page under **Settings → Open Stories** for feed metadata defaults.
+- Publishes an Open Stories-compatible JSON feed at `/open-stories.json`.
+
 ## Notes Custom Post Type
 
 `inc/notes.php` provides a `note` post type for short-form posts, with:

--- a/blocks/open-stories-viewer/block.json
+++ b/blocks/open-stories-viewer/block.json
@@ -1,0 +1,41 @@
+{
+  "apiVersion": 3,
+  "name": "child/open-stories-viewer",
+  "title": "Open Stories Viewer",
+  "category": "widgets",
+  "icon": "format-video",
+  "description": "Display an Open Stories feed using the open-stories-element web component.",
+  "supports": {
+    "html": false
+  },
+  "attributes": {
+    "feedUrl": {
+      "type": "string",
+      "default": ""
+    },
+    "buttonText": {
+      "type": "string",
+      "default": "View Stories"
+    },
+    "loading": {
+      "type": "string",
+      "default": "eager"
+    },
+    "duration": {
+      "type": "number",
+      "default": 5
+    },
+    "showMetadata": {
+      "type": "boolean",
+      "default": false
+    },
+    "isHighlight": {
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "textdomain": "child",
+  "editorScript": "file:./index.js",
+  "editorStyle": "file:./editor.css",
+  "style": "file:./style.css"
+}

--- a/blocks/open-stories-viewer/editor.css
+++ b/blocks/open-stories-viewer/editor.css
@@ -1,0 +1,6 @@
+.wp-block-child-open-stories-viewer {
+	border: 1px dashed #dcdcde;
+	padding: 16px;
+	border-radius: 6px;
+	background: #fff;
+}

--- a/blocks/open-stories-viewer/index.js
+++ b/blocks/open-stories-viewer/index.js
@@ -1,0 +1,83 @@
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	PanelBody,
+	TextControl,
+	SelectControl,
+	RangeControl,
+	ToggleControl,
+} from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
+import metadata from './block.json';
+import './editor.css';
+import './style.css';
+
+function Edit( { attributes, setAttributes } ) {
+	const {
+		feedUrl = '',
+		buttonText = 'View Stories',
+		loading = 'eager',
+		duration = 5,
+		showMetadata = false,
+		isHighlight = false,
+	} = attributes;
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Open Stories Settings', 'child' ) }>
+					<TextControl __next40pxDefaultSize __nextHasNoMarginBottom
+						label={ __( 'Feed URL', 'child' ) }
+						value={ feedUrl }
+						onChange={ ( value ) => setAttributes( { feedUrl: value } ) }
+						placeholder={ __( 'https://example.com/open-stories.json', 'child' ) }
+					/>
+					<TextControl __next40pxDefaultSize __nextHasNoMarginBottom
+						label={ __( 'Button text', 'child' ) }
+						value={ buttonText }
+						onChange={ ( value ) => setAttributes( { buttonText: value } ) }
+					/>
+					<SelectControl
+						label={ __( 'Loading mode', 'child' ) }
+						value={ loading }
+						onChange={ ( value ) => setAttributes( { loading: value } ) }
+						options={ [
+							{ label: __( 'Eager', 'child' ), value: 'eager' },
+							{ label: __( 'Lazy', 'child' ), value: 'lazy' },
+						] }
+					/>
+					<RangeControl
+						label={ __( 'Default story duration (seconds)', 'child' ) }
+						value={ duration }
+						onChange={ ( value ) => setAttributes( { duration: value || 5 } ) }
+						min={ 1 }
+						max={ 30 }
+					/>
+					<ToggleControl
+						label={ __( 'Show metadata/captions', 'child' ) }
+						checked={ showMetadata }
+						onChange={ ( value ) => setAttributes( { showMetadata: value } ) }
+					/>
+					<ToggleControl
+						label={ __( 'Highlight mode (no read history)', 'child' ) }
+						checked={ isHighlight }
+						onChange={ ( value ) => setAttributes( { isHighlight: value } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...useBlockProps() }>
+				{ feedUrl ? (
+					<ServerSideRender block={ metadata.name } attributes={ attributes } />
+				) : (
+					<p>{ __( 'Add an Open Stories feed URL in block settings.', 'child' ) }</p>
+				) }
+			</div>
+		</>
+	);
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/blocks/open-stories-viewer/render.php
+++ b/blocks/open-stories-viewer/render.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Render Open Stories Viewer block.
+ *
+ * @return callable
+ */
+
+return function( $attributes ) {
+	$feed_url = isset( $attributes['feedUrl'] ) ? trim( (string) $attributes['feedUrl'] ) : '';
+
+	if ( '' === $feed_url || ! wp_http_validate_url( $feed_url ) ) {
+		return sprintf(
+			'<p %s>%s</p>',
+			get_block_wrapper_attributes(),
+			esc_html__( 'Please provide a valid Open Stories feed URL.', 'child' )
+		);
+	}
+
+	$button_text   = isset( $attributes['buttonText'] ) ? (string) $attributes['buttonText'] : __( 'View Stories', 'child' );
+	$loading       = ( isset( $attributes['loading'] ) && 'lazy' === $attributes['loading'] ) ? 'lazy' : 'eager';
+	$duration      = isset( $attributes['duration'] ) ? max( 1, min( 30, (int) $attributes['duration'] ) ) : 5;
+	$show_metadata = ! empty( $attributes['showMetadata'] );
+	$is_highlight  = ! empty( $attributes['isHighlight'] );
+
+	$script_handle = 'child-open-stories-element';
+	if ( ! wp_script_is( $script_handle, 'registered' ) ) {
+		wp_register_script(
+			$script_handle,
+			'https://unpkg.com/open-stories-element@0.0.30',
+			[],
+			null,
+			true
+		);
+		wp_script_add_data( $script_handle, 'type', 'module' );
+	}
+	wp_enqueue_script( $script_handle );
+
+	$attrs = [
+		'src="' . esc_url( $feed_url ) . '"',
+		'loading="' . esc_attr( $loading ) . '"',
+		'duration="' . esc_attr( (string) $duration ) . '"',
+	];
+
+	if ( $show_metadata ) {
+		$attrs[] = 'show-metadata';
+	}
+
+	if ( $is_highlight ) {
+		$attrs[] = 'is-highlight';
+	}
+
+	return sprintf(
+		'<div %1$s><open-stories %2$s>%3$s</open-stories></div>',
+		get_block_wrapper_attributes(),
+		implode( ' ', $attrs ),
+		esc_html( $button_text )
+	);
+};

--- a/blocks/open-stories-viewer/style.css
+++ b/blocks/open-stories-viewer/style.css
@@ -1,0 +1,11 @@
+.wp-block-child-open-stories-viewer open-stories {
+	display: inline-block;
+}
+
+.wp-block-child-open-stories-viewer open-stories:not(:defined) {
+	display: inline-block;
+	padding: 0.5rem 0.85rem;
+	border-radius: 999px;
+	background: #111;
+	color: #fff;
+}

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -28,6 +28,10 @@ function child_get_dynamic_blocks(): array {
 			'block_name'  => 'child/pixelfed-feed',
 			'render_file' => 'blocks/pixelfed-feed/render.php',
 		],
+		'open-stories-viewer'      => [
+			'block_name'  => 'child/open-stories-viewer',
+			'render_file' => 'blocks/open-stories-viewer/render.php',
+		],
 		'popular-posts'            => [
 			'block_name'  => 'child/popular-posts',
 			'render_file' => 'blocks/popular-posts/render.php',

--- a/inc/open-stories.php
+++ b/inc/open-stories.php
@@ -1,0 +1,381 @@
+<?php
+/**
+ * Open Stories admin integration and feed endpoint.
+ *
+ * @package TwentyTwentyFiveChild
+ */
+
+const CHILD_OPEN_STORIES_POST_TYPE = 'child_story';
+
+/**
+ * Register a story post type used to author Open Stories items.
+ */
+function child_register_open_stories_post_type(): void {
+	$labels = [
+		'name'               => __( 'Open Stories', 'child' ),
+		'singular_name'      => __( 'Open Story', 'child' ),
+		'add_new'            => __( 'Add Story', 'child' ),
+		'add_new_item'       => __( 'Add New Story', 'child' ),
+		'edit_item'          => __( 'Edit Story', 'child' ),
+		'new_item'           => __( 'New Story', 'child' ),
+		'view_item'          => __( 'View Story', 'child' ),
+		'search_items'       => __( 'Search Stories', 'child' ),
+		'not_found'          => __( 'No stories found.', 'child' ),
+		'not_found_in_trash' => __( 'No stories found in trash.', 'child' ),
+		'menu_name'          => __( 'Open Stories', 'child' ),
+	];
+
+	register_post_type(
+		CHILD_OPEN_STORIES_POST_TYPE,
+		[
+			'labels'             => $labels,
+			'public'             => false,
+			'show_ui'            => true,
+			'show_in_menu'       => true,
+			'show_in_rest'       => true,
+			'menu_icon'          => 'dashicons-format-image',
+			'supports'           => [ 'title', 'thumbnail', 'editor', 'author' ],
+			'capability_type'    => 'post',
+			'publicly_queryable' => false,
+		]
+	);
+}
+add_action( 'init', 'child_register_open_stories_post_type' );
+
+/**
+ * Register story meta fields in REST and DB.
+ */
+function child_register_open_stories_meta(): void {
+	$meta_fields = [
+		'child_open_stories_url'              => [ 'type' => 'string' ],
+		'child_open_stories_mime_type'        => [ 'type' => 'string' ],
+		'child_open_stories_alt'              => [ 'type' => 'string' ],
+		'child_open_stories_video_title'      => [ 'type' => 'string' ],
+		'child_open_stories_caption'          => [ 'type' => 'string' ],
+		'child_open_stories_duration_seconds' => [ 'type' => 'number' ],
+		'child_open_stories_date_expired'     => [ 'type' => 'string' ],
+		'child_open_stories_content_warning'  => [ 'type' => 'string' ],
+	];
+
+	foreach ( $meta_fields as $meta_key => $schema ) {
+		register_post_meta(
+			CHILD_OPEN_STORIES_POST_TYPE,
+			$meta_key,
+			[
+				'show_in_rest'       => [ 'schema' => $schema ],
+				'single'             => true,
+				'type'               => $schema['type'],
+				'sanitize_callback'  => 'sanitize_text_field',
+				'auth_callback'      => static fn() => current_user_can( 'edit_posts' ),
+				'default'            => '',
+			]
+		);
+	}
+}
+add_action( 'init', 'child_register_open_stories_meta' );
+
+/**
+ * Add meta box to story editor.
+ */
+function child_add_open_stories_meta_box(): void {
+	add_meta_box(
+		'child-open-stories-fields',
+		__( 'Open Stories Fields', 'child' ),
+		'child_render_open_stories_meta_box',
+		CHILD_OPEN_STORIES_POST_TYPE,
+		'normal',
+		'high'
+	);
+}
+add_action( 'add_meta_boxes', 'child_add_open_stories_meta_box' );
+
+/**
+ * Render fields used by Open Stories feed.
+ */
+function child_render_open_stories_meta_box( WP_Post $post ): void {
+	wp_nonce_field( 'child_open_stories_save', 'child_open_stories_nonce' );
+
+	$fields = [
+		'child_open_stories_url'              => __( 'Media URL (required)', 'child' ),
+		'child_open_stories_mime_type'        => __( 'MIME type (required, image/* or video/*)', 'child' ),
+		'child_open_stories_alt'              => __( 'Image alt text', 'child' ),
+		'child_open_stories_video_title'      => __( 'Video title/description', 'child' ),
+		'child_open_stories_caption'          => __( 'Caption', 'child' ),
+		'child_open_stories_duration_seconds' => __( 'Duration in seconds', 'child' ),
+		'child_open_stories_date_expired'     => __( 'Expiration date (ISO 8601)', 'child' ),
+		'child_open_stories_content_warning'  => __( 'Content warning', 'child' ),
+	];
+
+	echo '<table class="form-table" role="presentation">';
+	foreach ( $fields as $field => $label ) {
+		$value = get_post_meta( $post->ID, $field, true );
+		echo '<tr><th><label for="' . esc_attr( $field ) . '">' . esc_html( $label ) . '</label></th><td>';
+		echo '<input class="regular-text" type="text" id="' . esc_attr( $field ) . '" name="' . esc_attr( $field ) . '" value="' . esc_attr( (string) $value ) . '" />';
+		echo '</td></tr>';
+	}
+	echo '</table>';
+}
+
+/**
+ * Save story meta fields.
+ */
+function child_save_open_stories_meta( int $post_id ): void {
+	if ( ! isset( $_POST['child_open_stories_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['child_open_stories_nonce'] ) ), 'child_open_stories_save' ) ) {
+		return;
+	}
+
+	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+		return;
+	}
+
+	if ( get_post_type( $post_id ) !== CHILD_OPEN_STORIES_POST_TYPE || ! current_user_can( 'edit_post', $post_id ) ) {
+		return;
+	}
+
+	$meta_keys = [
+		'child_open_stories_url',
+		'child_open_stories_mime_type',
+		'child_open_stories_alt',
+		'child_open_stories_video_title',
+		'child_open_stories_caption',
+		'child_open_stories_duration_seconds',
+		'child_open_stories_date_expired',
+		'child_open_stories_content_warning',
+	];
+
+	foreach ( $meta_keys as $meta_key ) {
+		$raw = wp_unslash( $_POST[ $meta_key ] ?? '' );
+		update_post_meta( $post_id, $meta_key, sanitize_text_field( $raw ) );
+	}
+}
+add_action( 'save_post', 'child_save_open_stories_meta' );
+
+/**
+ * Register Open Stories settings page.
+ */
+function child_register_open_stories_settings_page(): void {
+	add_options_page(
+		__( 'Open Stories Settings', 'child' ),
+		__( 'Open Stories', 'child' ),
+		'manage_options',
+		'child-open-stories',
+		'child_render_open_stories_settings_page'
+	);
+}
+add_action( 'admin_menu', 'child_register_open_stories_settings_page' );
+
+/**
+ * Register Open Stories options.
+ */
+function child_register_open_stories_settings(): void {
+	register_setting( 'child_open_stories', 'child_open_stories_feed_title', [
+		'type'              => 'string',
+		'sanitize_callback' => 'sanitize_text_field',
+		'default'           => get_bloginfo( 'name' ) . ' Stories',
+	] );
+
+	register_setting( 'child_open_stories', 'child_open_stories_feed_url', [
+		'type'              => 'string',
+		'sanitize_callback' => 'esc_url_raw',
+		'default'           => home_url( '/open-stories.json' ),
+	] );
+
+	register_setting( 'child_open_stories', 'child_open_stories_author_name', [
+		'type'              => 'string',
+		'sanitize_callback' => 'sanitize_text_field',
+		'default'           => get_bloginfo( 'name' ),
+	] );
+
+	register_setting( 'child_open_stories', 'child_open_stories_author_url', [
+		'type'              => 'string',
+		'sanitize_callback' => 'esc_url_raw',
+		'default'           => home_url( '/' ),
+	] );
+
+	add_settings_section(
+		'child_open_stories_section',
+		__( 'Feed metadata', 'child' ),
+		static function(): void {
+			echo '<p>' . esc_html__( 'Configure Open Stories feed defaults and publish stories from the Open Stories admin menu.', 'child' ) . '</p>';
+		},
+		'child-open-stories'
+	);
+
+	$fields = [
+		'child_open_stories_feed_title'  => __( 'Feed title', 'child' ),
+		'child_open_stories_feed_url'    => __( 'Feed URL', 'child' ),
+		'child_open_stories_author_name' => __( 'Default author name', 'child' ),
+		'child_open_stories_author_url'  => __( 'Default author URL', 'child' ),
+	];
+
+	foreach ( $fields as $option => $label ) {
+		add_settings_field(
+			$option,
+			$label,
+			static function() use ( $option ): void {
+				$value = (string) get_option( $option, '' );
+				echo '<input type="text" class="regular-text" name="' . esc_attr( $option ) . '" value="' . esc_attr( $value ) . '" />';
+			},
+			'child-open-stories',
+			'child_open_stories_section'
+		);
+	}
+}
+add_action( 'admin_init', 'child_register_open_stories_settings' );
+
+/**
+ * Render Open Stories settings page.
+ */
+function child_render_open_stories_settings_page(): void {
+	?>
+	<div class="wrap">
+		<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+		<p><?php echo esc_html__( 'Feed endpoint:', 'child' ); ?> <code><?php echo esc_html( home_url( '/open-stories.json' ) ); ?></code></p>
+		<form method="post" action="options.php">
+			<?php
+			settings_fields( 'child_open_stories' );
+			do_settings_sections( 'child-open-stories' );
+			submit_button( __( 'Save Settings', 'child' ) );
+			?>
+		</form>
+	</div>
+	<?php
+}
+
+/**
+ * Register a public Open Stories feed endpoint.
+ */
+function child_register_open_stories_rewrite(): void {
+	add_rewrite_rule( '^open-stories\.json$', 'index.php?child_open_stories_feed=1', 'top' );
+}
+add_action( 'init', 'child_register_open_stories_rewrite' );
+
+/**
+ * Register query var for feed endpoint.
+ *
+ * @param string[] $vars Query vars.
+ * @return string[]
+ */
+function child_add_open_stories_query_var( array $vars ): array {
+	$vars[] = 'child_open_stories_feed';
+	return $vars;
+}
+add_filter( 'query_vars', 'child_add_open_stories_query_var' );
+
+/**
+ * Emit JSON feed for /open-stories.json requests.
+ */
+function child_maybe_render_open_stories_feed(): void {
+	if ( '1' !== get_query_var( 'child_open_stories_feed' ) ) {
+		return;
+	}
+
+	$stories = get_posts(
+		[
+			'post_type'      => CHILD_OPEN_STORIES_POST_TYPE,
+			'post_status'    => 'publish',
+			'posts_per_page' => 100,
+			'orderby'        => 'date',
+			'order'          => 'DESC',
+		]
+	);
+
+	$default_author_name = (string) get_option( 'child_open_stories_author_name', get_bloginfo( 'name' ) );
+	$default_author_url  = (string) get_option( 'child_open_stories_author_url', home_url( '/' ) );
+
+	$items = array_values(
+		array_filter(
+			array_map(
+				static function( WP_Post $story ) use ( $default_author_name, $default_author_url ): ?array {
+					$url       = (string) get_post_meta( $story->ID, 'child_open_stories_url', true );
+					$mime_type = (string) get_post_meta( $story->ID, 'child_open_stories_mime_type', true );
+
+					if ( '' === $url || '' === $mime_type ) {
+						return null;
+					}
+
+					$open_story = [
+						'url'                => esc_url_raw( $url ),
+						'mime_type'          => sanitize_text_field( $mime_type ),
+						'date_expired'       => sanitize_text_field( (string) get_post_meta( $story->ID, 'child_open_stories_date_expired', true ) ),
+						'content_warning'    => sanitize_text_field( (string) get_post_meta( $story->ID, 'child_open_stories_content_warning', true ) ),
+						'duration_in_seconds'=> (float) get_post_meta( $story->ID, 'child_open_stories_duration_seconds', true ),
+					];
+
+					if ( str_starts_with( $mime_type, 'image/' ) ) {
+						$open_story['alt']     = sanitize_text_field( (string) get_post_meta( $story->ID, 'child_open_stories_alt', true ) );
+						$open_story['caption'] = sanitize_text_field( (string) get_post_meta( $story->ID, 'child_open_stories_caption', true ) );
+					} else {
+						$open_story['title'] = sanitize_text_field( (string) get_post_meta( $story->ID, 'child_open_stories_video_title', true ) );
+					}
+
+					$open_story = array_filter(
+						$open_story,
+						static function( $value ): bool {
+							if ( is_numeric( $value ) ) {
+								return (float) $value > 0;
+							}
+
+							return '' !== (string) $value;
+						}
+					);
+
+					return [
+						'id'           => (string) $story->ID,
+						'content_text' => wp_strip_all_tags( (string) $story->post_content ),
+						'authors'      => [
+							[
+								'name' => $default_author_name,
+								'url'  => esc_url_raw( $default_author_url ),
+							],
+						],
+						'_open_stories' => $open_story,
+					];
+				},
+				$stories
+			)
+		)
+	);
+
+	$feed = [
+		'version'       => 'https://jsonfeed.org/version/1.1',
+		'title'         => (string) get_option( 'child_open_stories_feed_title', get_bloginfo( 'name' ) . ' Stories' ),
+		'feed_url'      => (string) get_option( 'child_open_stories_feed_url', home_url( '/open-stories.json' ) ),
+		'_open_stories' => [
+			'version' => '0.0.9',
+		],
+		'items'         => $items,
+	];
+
+	status_header( 200 );
+	nocache_headers();
+	header( 'Content-Type: application/feed+json; charset=' . get_option( 'blog_charset' ) );
+	echo wp_json_encode( $feed, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+	exit;
+}
+add_action( 'template_redirect', 'child_maybe_render_open_stories_feed' );
+
+/**
+ * Flush rewrite rules once for Open Stories feed route.
+ */
+function child_maybe_flush_open_stories_rewrite_rules(): void {
+	if ( '1' === get_option( 'child_open_stories_rewrite_flushed' ) ) {
+		return;
+	}
+
+	child_register_open_stories_rewrite();
+	flush_rewrite_rules( false );
+	update_option( 'child_open_stories_rewrite_flushed', '1' );
+}
+add_action( 'init', 'child_maybe_flush_open_stories_rewrite_rules', 20 );
+
+/**
+ * Ensure Open Stories rewrite is refreshed on theme activation.
+ */
+function child_flush_open_stories_rewrite_on_switch(): void {
+	delete_option( 'child_open_stories_rewrite_flushed' );
+	child_register_open_stories_rewrite();
+	flush_rewrite_rules( false );
+	update_option( 'child_open_stories_rewrite_flushed', '1' );
+}
+add_action( 'after_switch_theme', 'child_flush_open_stories_rewrite_on_switch' );


### PR DESCRIPTION
### Motivation
- Provide a first-class Open Stories workflow in the child theme so site admins can author story items in wp-admin and publish an Open Stories-compatible JSON feed for consumers. 
- Expose feed metadata and defaults in the admin so feeds are configurable without code changes. 
- Reuse the theme's existing `inc/*.php` bootstrap to keep integration modular and automatically loaded.

### Description
- Added a new module `inc/open-stories.php` that registers an `Open Stories` custom post type and related meta needed by the Open Stories spec. 
- Registered post meta via `register_post_meta` (REST-aware) and added an admin meta box plus a secure save handler that verifies nonces and capabilities. 
- Added a `Settings → Open Stories` options page and settings (`child_open_stories_feed_title`, `child_open_stories_feed_url`, `child_open_stories_author_name`, `child_open_stories_author_url`). 
- Implemented a public feed at `/open-stories.json` by adding a rewrite rule, query var, `template_redirect` JSON emitter that outputs a JSON Feed with `_open_stories.version = 0.0.9`, and one-time rewrite-flush helpers for activation. 
- Updated `README.md` to document the new Open Stories feature and admin locations, and relied on the existing bootstrap autoloader so no extra include changes were required.

### Testing
- Ran PHP lint on the new module with `php -l inc/open-stories.php` which succeeded. 
- Ran PHP lint on the bootstrap and entrypoint with `php -l inc/bootstrap.php` and `php -l functions.php` which both succeeded. 
- No other automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5a44274d88325badca85a9c0370f2)