### PR TITLE
docs: refresh and standardize markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,35 @@
 # TwentyTwentyFive Child Theme
 
-A production-focused child theme for **Twenty Twenty-Five** that keeps customization logic modular, minimizes parent-theme duplication, and uses WordPress hooks/filters over template overrides.
+A production-focused child theme for **Twenty Twenty-Five** that keeps customization logic modular, minimizes parent-theme duplication, and prefers WordPress hooks/filters over template overrides.
 
-## Refactored Structure
+## Project Structure
 
 ```text
 .
 ├── assets/                      # Reserved for custom static assets.
-├── blocks/                      # Block source (editor JS/CSS + render callbacks).
-├── build/                       # Compiled block assets consumed by register_block_type().
+├── blocks/                      # Block source files (editor JS/CSS + render callbacks).
+├── build/                       # Compiled block assets used by register_block_type().
 ├── inc/
-│   ├── blocks.php               # Central dynamic block registration + shared style handling.
+│   ├── blocks.php               # Central dynamic block registration + shared styles.
 │   ├── bootstrap.php            # Child theme bootstrapping + module autoload.
+│   ├── book-rating.php
 │   ├── head-footer-injections.php
+│   ├── human-json.php
 │   ├── media-recommendation.php
 │   ├── notes.php
+│   ├── post-likes.php
 │   ├── videogame-recommendation.php
 │   └── visual-link-preview-async.php
 ├── functions.php                # Thin entrypoint (version constant + bootstrap include).
-└── style.css                    # Child metadata + minimal theme-level styles.
+└── style.css                    # Child theme metadata + minimal global styles.
 ```
 
 ## Architectural Decisions
 
-- **Single block registry**: all dynamic blocks are registered in one place (`inc/blocks.php`) to eliminate repeated boilerplate.
-- **Hook-based behavior**: settings pages, AJAX endpoints, and front-end enhancements are implemented with core actions/filters.
-- **Minimal `functions.php`**: startup logic is delegated to `inc/bootstrap.php` for maintainability.
-- **No unnecessary template overrides**: the child theme favors extensibility via block render callbacks and hooks.
+- **Single block registry:** Dynamic blocks are registered in one place (`inc/blocks.php`) to reduce repeated boilerplate.
+- **Hook-based behavior:** Settings pages, AJAX endpoints, and front-end enhancements use core WordPress actions/filters.
+- **Minimal `functions.php`:** Startup logic is delegated to `inc/bootstrap.php` for maintainability.
+- **Minimal template overrides:** The child theme favors extensibility through block render callbacks and hooks.
 
 ## Dynamic Blocks Registered
 
@@ -35,22 +38,25 @@ A production-focused child theme for **Twenty Twenty-Five** that keeps customiza
 - `child/media-recommendation`
 - `child/pixelfed-feed`
 - `child/popular-posts`
+- `child/post-likes`
 - `child/videogame-recommendation`
 - `child/visual-link-preview`
 
 Each block:
 - registers from `build/<slug>`
-- uses server-side render callback from `blocks/<slug>/render.php`
+- uses a server-side render callback from `blocks/<slug>/render.php` (where applicable)
 - receives block style enqueueing plus a global style fallback for compatibility
 
-## API-backed Features
+## API-Backed Features
 
 ### Media Recommendation (TMDB)
+
 - Admin settings page under **Settings → Media Recommendation**.
 - API key lookup order: option `child_tmdb_api_key`, then `TMDB_API_KEY` constant fallback.
 - Editor AJAX endpoint: `wp_ajax_child_tmdb_search`.
 
 ### Videogame Recommendation (RAWG)
+
 - Admin settings page under **Settings → Videogame Recommendation**.
 - API key lookup order: option `child_rawg_api_key`, then `RAWG_API_KEY` constant fallback.
 - Editor AJAX endpoint: `wp_ajax_child_rawg_search`.
@@ -58,9 +64,10 @@ Each block:
 ## Notes Custom Post Type
 
 `inc/notes.php` provides a `note` post type for short-form posts, with:
-- generated internal titles for title-less notes,
-- hidden `core/post-title` output on front end for notes,
-- guarded rewrite flush logic for reliable `/notes` routing.
+
+- generated internal titles for title-less notes
+- hidden `core/post-title` output on the front end for notes
+- guarded rewrite flush logic for reliable `/notes` routing
 
 ## Development
 
@@ -75,7 +82,7 @@ To create a distribution package:
 npm run dist
 ```
 
-## Compatibility & Maintenance
+## Compatibility and Maintenance
 
 - Keeps child-theme overrides intentionally minimal.
 - Uses consistent prefixed function names (`child_*`) to avoid collisions.

--- a/blocks/videogame-recommendation/README.md
+++ b/blocks/videogame-recommendation/README.md
@@ -1,67 +1,72 @@
 # Videogame Recommendation Block
 
-Ein WordPress Gutenberg Block zur Anzeige von Videospiel-Empfehlungen mit RAWG API Integration.
+A WordPress Gutenberg block for displaying videogame recommendations with RAWG API integration.
 
-## Funktionen
+## Features
 
-- **RAWG API Integration**: Durchsuche Videospiele und importiere automatisch Metadaten
-- **Light Mode Design**: Moderne Karten-UI im RAWG-Stil
-- **Plattform-Chips**: Farbcodierte Badges für Gaming-Plattformen
-- **Metadaten**: Release-Datum und Genres
-- **Responsive**: Optimiert für alle Bildschirmgrößen
-- **Performance**: Lazy Loading und optimierte Assets
+- **RAWG API integration:** Search games and import metadata automatically.
+- **Light mode design:** Modern card UI inspired by RAWG.
+- **Platform chips:** Color-coded badges for gaming platforms.
+- **Metadata:** Release date and genre display.
+- **Responsive layout:** Optimized for all screen sizes.
+- **Performance:** Lazy loading and optimized assets.
 
-## Struktur
+## Structure
 
-```
+```text
 videogame-recommendation/
-├── index.js              # Haupt-Block-Registrierung
-├── block.json            # Block-Konfiguration
-├── render.php            # Server-side Rendering
-├── style.css             # Frontend & Editor Styles
-├── editor.css            # Editor-spezifische Styles
-├── utils.js              # JavaScript Utilities
-├── utils.php             # PHP Utilities
+├── index.js              # Main block registration
+├── block.json            # Block configuration
+├── render.php            # Server-side rendering
+├── style.css             # Frontend + editor styles
+├── editor.css            # Editor-specific styles
+├── utils.js              # JavaScript utilities
+├── utils.php             # PHP utilities
 ├── components/
-│   ├── GamePreview.js    # Spielkarten-Komponente
-│   └── SearchResults.js  # Suchergebnis-Komponente
+│   ├── GamePreview.js    # Game card component
+│   └── SearchResults.js  # Search result component
 └── hooks/
-    └── useGameSearch.js  # Such-Hook
+    └── useGameSearch.js  # Search hook
 ```
 
-## Komponenten
+## Components
 
 ### GamePreview
-Zeigt die Spielkarte mit Cover, Plattformen, Titel und Metadaten an.
+
+Displays the game card with cover image, platforms, title, and metadata.
 
 ### SearchResults
-Zeigt Suchergebnisse in der Seitenleiste an.
+
+Displays search results in the editor sidebar.
 
 ### useGameSearch Hook
-Custom Hook für die Spielsuche-Logik.
+
+Custom hook for game-search logic.
 
 ## Utilities
 
-### utils.js
-- `getPlatformInfo()`: Platform-Name zu Display-Name und Farbe
-- `formatReleaseDate()`: Datum-Formatierung
-- `transformGameData()`: API-Daten zu Block-Format
+### `utils.js`
 
-### utils.php
-- `child_get_platform_info()`: PHP Version der Platform-Info-Funktion
+- `getPlatformInfo()`: Maps platform names to display names and colors.
+- `formatReleaseDate()`: Formats release dates.
+- `transformGameData()`: Transforms API data into block-friendly shape.
 
-## Plattform-Farben
+### `utils.php`
 
-| Plattform | Farbe |
-|-----------|-------|
-| PlayStation | #003087 |
-| Xbox | #107C10 |
-| Nintendo Switch | #E60012 |
-| PC | #0078D4 |
-| iOS | #555555 |
-| Android | #3DDC84 |
-| Linux | #FCC624 |
-| macOS | #999999 |
+- `child_get_platform_info()`: PHP equivalent of platform info mapping.
+
+## Platform Colors
+
+| Platform | Color |
+| --- | --- |
+| PlayStation | `#003087` |
+| Xbox | `#107C10` |
+| Nintendo Switch | `#E60012` |
+| PC | `#0078D4` |
+| iOS | `#555555` |
+| Android | `#3DDC84` |
+| Linux | `#FCC624` |
+| macOS | `#999999` |
 
 ## Development
 
@@ -75,4 +80,4 @@ npm run start
 
 ## API
 
-Verwendet die RAWG API für Spieldaten. API-Key in WordPress Admin unter Settings > Videogame Recommendation konfigurieren.
+Uses the RAWG API for game data. Configure the API key in WordPress Admin under **Settings → Videogame Recommendation**.

--- a/devlog.md
+++ b/devlog.md
@@ -1,109 +1,89 @@
 # Project: Replace WordPress Plugins with Child Theme Modules
 
----
-
 ## Jira Ticket 1 — Plugin Audit Documentation
 
-**Goal:**  
-Create a living document that lists all active WordPress plugins, their purpose, complexity, and feasibility of replacement by the child theme.
+**Goal**
+Create a living document that lists all active WordPress plugins, their purpose, complexity, and feasibility for replacement in the child theme.
 
-**Acceptance Criteria:**  
-- A markdown file `docs/plugin-audit.md` exists with a table including these columns: Plugin Name, Purpose, Complexity, Replaceable in Theme, Priority, and Notes.  
-- The document includes a clear explanation of complexity and priority definitions.  
+**Acceptance Criteria**
+- A Markdown file `docs/plugin-audit.md` exists with a table including: Plugin Name, Purpose, Complexity, Replaceable in Theme, Priority, and Notes.
+- The document includes clear definitions for complexity and priority.
 - The document is ready to be updated continuously during development.
-
----
 
 ## Jira Ticket 2 — Complete Plugin Inventory
 
-**Goal:**  
+**Goal**
 Populate the plugin audit document with all active plugins and their core purposes.
 
-**Acceptance Criteria:**  
-- All active plugins on the development site are listed by name and purpose in the audit document.  
-- No judgments or classifications are made yet; only listing is done.
-
----
+**Acceptance Criteria**
+- All active plugins on the development site are listed by name and purpose in the audit document.
+- No judgments or classifications are made yet; this ticket only covers inventory.
 
 ## Jira Ticket 3 — Establish Child Theme Base
 
-**Goal:**  
-Set up a functional child theme for TwentyTwentyFive that can be activated without errors.
+**Goal**
+Set up a functional child theme for Twenty Twenty-Five that can be activated without errors.
 
-**Acceptance Criteria:**  
-- Child theme folder with `style.css` and `functions.php` exists and references the parent correctly.  
-- Parent and child stylesheets are properly enqueued and load on the frontend.  
-- Theme activates in WordPress without errors or warnings.
-
----
+**Acceptance Criteria**
+- A child theme folder with `style.css` and `functions.php` exists and references the parent correctly.
+- Parent and child stylesheets are properly enqueued and load on the front end.
+- The theme activates in WordPress without errors or warnings.
 
 ## Jira Ticket 4 — Modular Code Structure
 
-**Goal:**  
-Create a modular code structure inside the child theme to allow incremental feature development.
+**Goal**
+Create a modular code structure inside the child theme to support incremental feature development.
 
-**Acceptance Criteria:**  
-- An `inc/` folder exists containing placeholder files for different functional areas (e.g., cleanup, SEO, forms).  
-- These files are loaded automatically by the theme.  
+**Acceptance Criteria**
+- An `inc/` folder exists containing placeholder files for functional areas (for example: cleanup, SEO, forms).
+- These files are loaded automatically by the theme.
 - Theme activation remains stable and error-free.
-
----
 
 ## Jira Ticket 5 — Plugin Complexity Assessment
 
-**Goal:**  
-Assign complexity levels and priorities to each plugin based on potential ease or difficulty of replacement.
+**Goal**
+Assign complexity levels and priorities to each plugin based on likely replacement difficulty.
 
-**Acceptance Criteria:**  
-- Complexity (Low, Medium, High) and Priority (High, Medium, Low) are assigned to each plugin in the audit document.  
-- Rationales for ratings are documented clearly in notes.
-
----
+**Acceptance Criteria**
+- Complexity (Low, Medium, High) and Priority (High, Medium, Low) are assigned to each plugin in the audit document.
+- Rationales for ratings are clearly documented in notes.
 
 ## Jira Ticket 6 — Replacement Strategy Documentation
 
-**Goal:**  
-For each high-priority plugin, document which features will be replaced in the child theme and any limitations or expected differences.
+**Goal**
+For each high-priority plugin, document the features that will be replaced in the child theme and any limitations or expected differences.
 
-**Acceptance Criteria:**  
-- Each high-priority plugin has a documented replacement plan inside the corresponding module file as a developer comment.  
+**Acceptance Criteria**
+- Each high-priority plugin has a documented replacement plan inside the relevant module file as a developer comment.
 - Plans are clear and provide enough context to guide implementation.
-
----
 
 ## Jira Ticket 7 — Implement Plugin Replacement Module
 
-**Goal:**  
+**Goal**
 Deliver a fully functional child theme module that replicates the core functionality of a prioritized plugin.
 
-**Acceptance Criteria:**  
-- Module covers the core features targeted for replacement.  
-- No regressions or errors are introduced.  
-- Module code adheres to WordPress standards and best practices.  
+**Acceptance Criteria**
+- The module covers the targeted core features.
+- No regressions or errors are introduced.
+- Module code follows WordPress standards and best practices.
 - User-facing strings are translatable.
-
----
 
 ## Jira Ticket 8 — Plugin Deactivation and Verification
 
-**Goal:**  
-Safely deactivate the replaced plugin and verify the child theme module fully assumes its responsibilities.
+**Goal**
+Safely deactivate the replaced plugin and verify that the child theme module fully assumes its responsibilities.
 
-**Acceptance Criteria:**  
-- Plugin deactivation causes no loss of functionality or site errors.  
-- The replacement module performs equivalently or better.  
-- Any deviations are noted in the audit document.
-
----
+**Acceptance Criteria**
+- Plugin deactivation causes no loss of functionality or site errors.
+- The replacement module performs equivalently or better.
+- Any deviations are documented in the audit document.
 
 ## Jira Ticket 9 — Iterate Replacement Process
 
-**Goal:**  
-Continue replacing additional prioritized plugins with child theme modules following the defined workflow.
+**Goal**
+Continue replacing additional prioritized plugins with child theme modules by following the defined workflow.
 
-**Acceptance Criteria:**  
-- Audit document and modular codebase remain up to date.  
-- Site remains stable throughout replacements.  
-- Each plugin’s replacement is tracked with success criteria met.
-
----
+**Acceptance Criteria**
+- The audit document and modular codebase remain up to date.
+- The site remains stable throughout replacements.
+- Each plugin replacement is tracked and meets success criteria.

--- a/releases/v1.1.3.md
+++ b/releases/v1.1.3.md
@@ -1,17 +1,20 @@
 # Release v1.1.3
 
-Release date: 2025-12-29
+**Release date:** 2025-12-29
 
-Highlights
-- README fully rewritten in English to document theme structure and blocks.
-- Removed automatic view-count tracking and cookie debounce from the Popular Posts module; the block now renders a curated list chosen by editors.
-- Version bumped to `1.1.3` and annotated git tag `v1.1.3` created and pushed.
+## Highlights
 
-Files changed (not exhaustive)
+- README was fully rewritten in English to document theme structure and blocks.
+- Automatic view-count tracking and cookie debounce were removed from the Popular Posts module. The block now renders a curated list selected by editors.
+- Version bumped to `1.1.3`, and annotated Git tag `v1.1.3` was created and pushed.
+
+## Files Changed (Not Exhaustive)
+
 - `README.md` — replaced with English documentation.
 - `inc/popular-posts.php` — removed view-count logic.
 - `dist/twentytwentyfive-child/inc/popular-posts.php` — synced removal in distribution copy.
 - `package.json` — version bumped to `1.1.3`.
 
-Notes
+## Notes
+
 - `dist/` remains in `.gitignore`; distribution artifacts are produced by `npm run dist`.

--- a/releases/v1.1.4.md
+++ b/releases/v1.1.4.md
@@ -1,23 +1,26 @@
 # Release v1.1.4
 
-Release date: 2025-01-02
+**Release date:** 2025-01-02
 
-Highlights
-- **Visual Link Preview:** Changed from async to synchronous metadata fetching to always display rich cards with image/title/description immediately.
-- **Performance Optimizations:** Cached `glob()` results in functions.php to avoid repeated filesystem operations on every request.
-- **Performance Optimizations:** Added static caching for CSS file existence and modification time checks across all modules (book-rating, popular-posts, visual-link-preview).
-- These improvements reduce filesystem I/O operations and improve page load performance.
-- Version bumped to `1.1.4` and annotated git tag `v1.1.4` created and pushed.
+## Highlights
 
-Files changed
-- `inc/visual-link-preview.php` — changed from async to synchronous metadata fetching.
-- `inc/visual-link-preview-async.php` — (legacy file for reference).
-- `functions.php` — added static caching for glob() results and CSS file checks.
-- `inc/book-rating.php` — added static caching for CSS file checks.
-- `inc/popular-posts.php` — added static caching for CSS file checks.
+- **Visual Link Preview:** Changed from async to synchronous metadata fetching so rich cards (image/title/description) display immediately.
+- **Performance:** Cached `glob()` results in `functions.php` to avoid repeated filesystem operations on every request.
+- **Performance:** Added static caching for CSS file existence and modification-time checks across modules (`book-rating`, `popular-posts`, `visual-link-preview`).
+- These changes reduce filesystem I/O and improve page-load performance.
+- Version bumped to `1.1.4`, and annotated Git tag `v1.1.4` was created and pushed.
+
+## Files Changed
+
+- `inc/visual-link-preview.php` — switched from async to synchronous metadata fetching.
+- `inc/visual-link-preview-async.php` — retained as a legacy reference file.
+- `functions.php` — added static caching for `glob()` and CSS checks.
+- `inc/book-rating.php` — added static caching for CSS checks.
+- `inc/popular-posts.php` — added static caching for CSS checks.
 - `package.json` — version bumped to `1.1.4`.
 - `style.css` — version bumped to `1.1.4`.
 - `CHANGELOG.md` — updated with release notes.
 
-Notes
+## Notes
+
 - `dist/` remains in `.gitignore`; distribution artifacts are produced by `npm run dist`.

--- a/releases/v1.2.0.md
+++ b/releases/v1.2.0.md
@@ -1,41 +1,46 @@
 # Release v1.2.0
 
-Release date: 2026-01-02
+**Release date:** 2026-01-02
 
-Highlights
+## Highlights
 
 ### New Features
-- **Media Recommendation Block (PR #17):** Gutenberg-Block für Filme und TV-Serien mit TMDB-API-Integration
-  - Ambilight-Gradient-Effekt basierend auf Poster-Farben
-  - WordPress-Admin-Einstellungsseite für TMDB-API-Schlüssel-Konfiguration
-  - Verwendung der WordPress-Locale für TMDB-API-Sprachparameter
-  - Umfassende Fehlerbehandlung und Sicherheitsverbesserungen
+
+- **Media Recommendation Block (PR #17):** Gutenberg block for movies and TV series with TMDB API integration.
+  - Ambilight gradient effect based on poster colors.
+  - WordPress admin settings page for TMDB API key configuration.
+  - Uses WordPress locale for TMDB language parameter.
+  - Comprehensive error handling and security improvements.
 
 ### Documentation
-- **Cleanup:** Entfernung veralteter Dokumentationsdateien
-  - `CHANGELOG.md` (redundant mit Release-Notes)
-  - `IMPLEMENTATION_SUMMARY.md` (interne Dokumentation)
-  - `MEDIA_RECOMMENDATION_SETUP.md` (Setup-Info jetzt in README)
-  - `SETTINGS_PAGE_GUIDE.md` (Visual Guide für Settings)
-  - `VISUAL_GUIDE.md` (Visual Documentation für Media Block)
 
-- **README Updates:** Dokumentation für neue Blöcke hinzugefügt
+- **Cleanup:** Removed outdated documentation files.
+  - `CHANGELOG.md` (redundant with release notes)
+  - `IMPLEMENTATION_SUMMARY.md` (internal summary)
+  - `MEDIA_RECOMMENDATION_SETUP.md` (setup moved into README)
+  - `SETTINGS_PAGE_GUIDE.md` (visual guide for settings)
+  - `VISUAL_GUIDE.md` (visual documentation for media block)
 
-Files changed
+- **README updates:** Added documentation for new blocks.
+
+## Files Changed
 
 ### Media Recommendation Block
-- `blocks/media-recommendation/` — Neuer Block mit index.js, block.json, render.php, editor.css, style.css
-- `inc/media-recommendation.php` — Server-seitige Logik, TMDB-API-Integration, Ambilight-Berechnung, Settings-Seite
-- `build/media-recommendation/` — Kompilierte Build-Artefakte
 
-### Documentation & Cleanup
-- Deleted: `CHANGELOG.md`, `IMPLEMENTATION_SUMMARY.md`, `MEDIA_RECOMMENDATION_SETUP.md`, `SETTINGS_PAGE_GUIDE.md`, `VISUAL_GUIDE.md`
-- `README.md` — Updates für neue Blöcke und Entfernung veralteter Referenzen
-- `package.json` — Version auf `1.2.0` erhöht
-- `style.css` — Version auf `1.2.0` erhöht
+- `blocks/media-recommendation/` — new block with `index.js`, `block.json`, `render.php`, `editor.css`, and `style.css`.
+- `inc/media-recommendation.php` — server-side logic, TMDB API integration, ambilight calculation, settings page.
+- `build/media-recommendation/` — compiled build artifacts.
 
-Notes
-- Dies ist ein Minor-Release mit neuen Features (Media Recommendation Gutenberg-Block)
-- Der Block erfordert API-Schlüssel (TMDB für Media Recommendation)
-- Konfiguration erfolgt über WordPress-Admin-Einstellungsseite
-- `dist/` bleibt in `.gitignore`; Distribution-Artefakte werden über `npm run dist` erstellt
+### Documentation and Cleanup
+
+- Deleted: `CHANGELOG.md`, `IMPLEMENTATION_SUMMARY.md`, `MEDIA_RECOMMENDATION_SETUP.md`, `SETTINGS_PAGE_GUIDE.md`, `VISUAL_GUIDE.md`.
+- `README.md` — updated for new blocks and removed stale references.
+- `package.json` — version bumped to `1.2.0`.
+- `style.css` — version bumped to `1.2.0`.
+
+## Notes
+
+- This is a minor release with new features (Media Recommendation Gutenberg block).
+- The block requires API keys (TMDB for Media Recommendation).
+- Configuration is available in the WordPress admin settings page.
+- `dist/` remains in `.gitignore`; distribution artifacts are produced by `npm run dist`.

--- a/releases/v1.2.1.md
+++ b/releases/v1.2.1.md
@@ -1,21 +1,24 @@
 # Release v1.2.1
 
-Release date: 2026-01-09
+**Release date:** 2026-01-09
 
-Highlights
-- **Media Recommendation block:** Fix ambilight by waiting for image load and adding safety guards.
-- **CI/CD:** Optimize release workflow to reuse artifacts, add release-published trigger, and declare explicit GITHUB_TOKEN permissions.
-- **Docs:** Add workflow automation notes to README.
+## Highlights
 
-Files changed
-- `inc/media-recommendation.php` — ensure poster image load before ambilight and add guards.
-- `build/` assets — regenerated for media-recommendation block (CSS/JS/index asset metadata).
+- **Media Recommendation block:** Fixed ambilight behavior by waiting for image load and adding safety guards.
+- **CI/CD:** Optimized release workflow to reuse artifacts, added release-published trigger, and declared explicit `GITHUB_TOKEN` permissions.
+- **Docs:** Added workflow automation notes to `README.md`.
+
+## Files Changed
+
+- `inc/media-recommendation.php` — ensured poster image loads before ambilight and added safety guards.
+- `build/` assets — regenerated for the media-recommendation block (CSS/JS/index asset metadata).
 - `package-lock.json` — dependency hash updates from rebuild.
 - `.github/workflows/build-release.yml` — artifact reuse, release trigger, explicit permissions.
-- `README.md` — document automated build/release workflow.
+- `README.md` — documented automated build/release workflow.
 - `package.json` — version bumped to `1.2.1`.
 - `style.css` — version bumped to `1.2.1`.
 
-Notes
+## Notes
+
 - Distribution artifacts remain out of VCS; use `npm run dist` to build packages.
-- No new features; this is a bugfix and workflow improvement release.
+- No new features; this is a bugfix and workflow-improvement release.

--- a/releases/v1.2.2.md
+++ b/releases/v1.2.2.md
@@ -1,20 +1,23 @@
 # Release v1.2.2
 
-Release date: 2026-01-24
+**Release date:** 2026-01-24
 
-Highlights
-- Dependencies aktualisiert: @wordpress/scripts und @wordpress/html-entities auf neueste Versionen
-- Nicht verwendetes Package simple-icons entfernt
-- Build-Ordner wird jetzt korrekt von Git ignoriert
-- Sicherheitslücken mit npm audit fix behoben
+## Highlights
 
-Files changed
-- `package.json` — Dependencies aktualisiert, simple-icons entfernt, Version auf 1.2.2 erhöht
-- `package-lock.json` — automatisch aktualisiert
-- `.gitignore` — Build-Ordner bleibt ignoriert
-- `build/` — nicht mehr im Git-Tracking
-- `style.css` — Version auf 1.2.2 erhöht
+- Updated dependencies: `@wordpress/scripts` and `@wordpress/html-entities`.
+- Removed unused `simple-icons` package.
+- Ensured the build folder remains ignored by Git.
+- Addressed vulnerabilities reported by `npm audit fix`.
 
-Notes
-- Breaking Changes wurden nicht durchgeführt (webpack-dev-server bleibt mit moderaten Schwachstellen)
-- Release enthält keine neuen Features, sondern Wartung und Security
+## Files Changed
+
+- `package.json` — dependency updates, removed `simple-icons`, version bumped to `1.2.2`.
+- `package-lock.json` — auto-updated.
+- `.gitignore` — build folder remains ignored.
+- `build/` — removed from Git tracking.
+- `style.css` — version bumped to `1.2.2`.
+
+## Notes
+
+- No breaking changes were introduced (`webpack-dev-server` remains with moderate known issues).
+- This release contains maintenance and security updates only.

--- a/releases/v1.2.3.md
+++ b/releases/v1.2.3.md
@@ -1,24 +1,27 @@
 # Release v1.2.3
 
-Release date: 2026-02-16
+**Release date:** 2026-02-16
 
-Highlights
-- Pixelfed RSS Feed Gutenberg Block hinzugefügt
-- Performance-Verbesserungen bei Block-Rendering
-- Code-Qualität und Dependencies auf dem neuesten Stand
+## Highlights
 
-Files changed
-- `blocks/pixelfed-feed/` — Neuer Block für RSS-Feed-Integration
-- `build/pixelfed-feed/` — Build-Dateien für den neuen Block
-- `inc/pixelfed-feed.php` — Backend-Logik für Pixelfed
-- `functions.php` — Integration neuer Block-Funktionen
+- Added Pixelfed RSS Feed Gutenberg block.
+- Improved block-rendering performance.
+- Updated dependencies and code quality tooling.
 
-Features
-- **Pixelfed RSS Feed Block**: Neue Unterstützung für RSS-Feeds von Pixelfed-Instanzen
-- Verbesserte Fehlerbehandlung und Sicherheit
-- Optimierte Lade-Performance
+## Files Changed
 
-Notes
-- Vollständig abwärtskompatibel mit vorherigen Versionen
-- Alle Blöcke sind stabil und produktionsreif
+- `blocks/pixelfed-feed/` — new block for RSS feed integration.
+- `build/pixelfed-feed/` — build artifacts for the new block.
+- `inc/pixelfed-feed.php` — backend logic for Pixelfed.
+- `functions.php` — integration of new block behavior.
 
+## Features
+
+- **Pixelfed RSS Feed block:** Support for RSS feeds from Pixelfed instances.
+- Improved error handling and security hardening.
+- Optimized loading performance.
+
+## Notes
+
+- Fully backward-compatible with previous versions.
+- All blocks are stable and production-ready.

--- a/releases/v1.3.0.md
+++ b/releases/v1.3.0.md
@@ -1,24 +1,28 @@
 # Release v1.3.0
 
-Release date: 2026-03-28
+**Release date:** 2026-03-28
 
-Highlights
-- Anonymous post likes Gutenberg block with size and alignment controls
-- human.json integration with admin-managed vouch settings
-- Refactored child theme bootstrap and block registration for better caching
+## Highlights
 
-Files changed
-- `blocks/post-likes/` — Anonymous likes block with editor controls
-- `inc/post-likes.php` — Likes handling and idempotent updates
-- `inc/human-json.php` — human.json routing and vouch management
-- `inc/bootstrap.php` — Registration and cache key improvements
-- `functions.php` — Integration updates for new features
+- Added an anonymous Post Likes Gutenberg block with size and alignment controls.
+- Added `human.json` integration with admin-managed vouch settings.
+- Refactored child-theme bootstrap and block registration for better caching.
 
-Features
-- **Post Likes**: Anonymous likes block with sizing and alignment options
-- **human.json**: Route setup, admin-configured vouch list, and rewrite handling
-- **Bootstrap**: Safer module caching and guardrails against stale paths
+## Files Changed
 
-Notes
-- Vollständig abwärtskompatibel mit vorherigen Versionen
-- Keine Datenmigration erforderlich
+- `blocks/post-likes/` — anonymous likes block with editor controls.
+- `inc/post-likes.php` — likes handling and idempotent updates.
+- `inc/human-json.php` — `human.json` routing and vouch management.
+- `inc/bootstrap.php` — registration and cache-key improvements.
+- `functions.php` — integration updates for new features.
+
+## Features
+
+- **Post Likes:** Anonymous likes block with sizing and alignment options.
+- **`human.json`:** Route setup, admin-configured vouch list, and rewrite handling.
+- **Bootstrap:** Safer module caching and guardrails against stale paths.
+
+## Notes
+
+- Fully backward-compatible with previous versions.
+- No data migration required.


### PR DESCRIPTION
### Motivation
- Improve clarity and consistency across project documentation and release notes to make onboarding and maintenance easier. 
- Replace mixed-language and slightly inconsistent notes with a single, clear English style and consistent sectioning for releases and developer guidance.
- Provide concise, up-to-date README and block-level READMEs so contributors can find module and API integration details quickly.

### Description
- Standardized and refreshed root `README.md` to a clearer Project Structure, Architectural Decisions, Dynamic Blocks, API notes, and Development instructions. 
- Rewrote `devlog.md` to a consistent Jira-ticket style with explicit `Goal` and `Acceptance Criteria` sections. 
- Rewrote `blocks/videogame-recommendation/README.md` in English and standardized Features, Structure, Components, Utilities, Platform Colors, Development, and API sections. 
- Normalized all release notes under `releases/*.md` to a consistent `Release date`, `Highlights`, `Files Changed`, `Features` (where applicable), and `Notes` layout and wording.

### Testing
- Ran the Markdown linter with `npx --yes markdownlint-cli2 "**/*.md"`, which reported many issues; the bulk of failures are from `node_modules` and strict MD013 (line-length) checks when linting repository-wide. 
- Performed a repository diff/whitespace check (`git diff --check`) which returned no whitespace or merge marker issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7db113728832599691f5ba290c7f0)