### PR TITLE
Post Likes: add CTA message and selectable emoji

### DIFF
--- a/blocks/post-likes/block.json
+++ b/blocks/post-likes/block.json
@@ -41,6 +41,14 @@
     "buttonErrorBorder": {
       "type": "string",
       "default": "#ff9ab6"
+    },
+    "ctaText": {
+      "type": "string",
+      "default": "Do you like this?"
+    },
+    "reactionEmoji": {
+      "type": "string",
+      "default": "❤️"
     }
   },
   "supports": {

--- a/blocks/post-likes/index.js
+++ b/blocks/post-likes/index.js
@@ -115,22 +115,13 @@ function Edit( { attributes, setAttributes } ) {
 							'child'
 						) }
 					/>
-					<SelectControl
+					<TextControl
 						label={ __( 'Emoji', 'child' ) }
 						value={ reactionEmoji }
-						options={ [
-							{ label: '❤️ Heart', value: '❤️' },
-							{ label: '💖 Sparkling Heart', value: '💖' },
-							{ label: '👍 Thumbs Up', value: '👍' },
-							{ label: '🔥 Fire', value: '🔥' },
-							{ label: '😂 Laugh', value: '😂' },
-							{ label: '🎉 Party', value: '🎉' },
-							{ label: '🍰 Cake', value: '🍰' },
-							{ label: '⭐ Star', value: '⭐' },
-						] }
 						onChange={ ( value ) =>
 							setAttributes( { reactionEmoji: value } )
 						}
+						help={ __( 'Paste any emoji you want to use.', 'child' ) }
 					/>
 				</PanelBody>
 				<PanelColorSettings

--- a/blocks/post-likes/index.js
+++ b/blocks/post-likes/index.js
@@ -180,10 +180,12 @@ function Edit( { attributes, setAttributes } ) {
 					{ ctaTextValue !== '' && (
 						<span className="child-post-likes__cta">{ ctaTextValue }</span>
 					) }
-					<span className="child-post-likes__icon" aria-hidden="true">
-						{ reactionEmoji }
+					<span className="child-post-likes__pill">
+						<span className="child-post-likes__icon" aria-hidden="true">
+							{ reactionEmoji }
+						</span>
+						<span className="child-post-likes__count">0</span>
 					</span>
-					<span className="child-post-likes__count">0</span>
 				</button>
 				<p className="child-post-likes__help">
 					{ __( 'Frontend visitors can toggle likes on this post.', 'child' ) }

--- a/blocks/post-likes/index.js
+++ b/blocks/post-likes/index.js
@@ -79,6 +79,9 @@ function Edit( { attributes, setAttributes } ) {
 
 	const blockProps = useBlockProps( { style } );
 
+	const ctaTextValue =
+		typeof ctaText === 'string' ? ctaText.trim() : '';
+
 	return (
 		<>
 			<BlockControls>
@@ -178,20 +181,22 @@ function Edit( { attributes, setAttributes } ) {
 				/>
 			</InspectorControls>
 			<div { ...blockProps }>
-			<button
-				type="button"
-				className="child-post-likes__button is-editor-preview"
-				disabled
-			>
-				<span className="child-post-likes__cta">{ ctaText }</span>
-				<span className="child-post-likes__icon" aria-hidden="true">
-					{ reactionEmoji }
-				</span>
-				<span className="child-post-likes__count">0</span>
-			</button>
-			<p className="child-post-likes__help">
-				{ __( 'Frontend visitors can toggle likes on this post.', 'child' ) }
-			</p>
+				<button
+					type="button"
+					className="child-post-likes__button is-editor-preview"
+					disabled
+				>
+					{ ctaTextValue !== '' && (
+						<span className="child-post-likes__cta">{ ctaTextValue }</span>
+					) }
+					<span className="child-post-likes__icon" aria-hidden="true">
+						{ reactionEmoji }
+					</span>
+					<span className="child-post-likes__count">0</span>
+				</button>
+				<p className="child-post-likes__help">
+					{ __( 'Frontend visitors can toggle likes on this post.', 'child' ) }
+				</p>
 			</div>
 		</>
 	);

--- a/blocks/post-likes/index.js
+++ b/blocks/post-likes/index.js
@@ -7,7 +7,7 @@ import {
 	PanelColorSettings,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { PanelBody, SelectControl } from '@wordpress/components';
+import { PanelBody, SelectControl, TextControl } from '@wordpress/components';
 import metadata from './block.json';
 import './editor.css';
 import './style.css';
@@ -41,6 +41,8 @@ function Edit( { attributes, setAttributes } ) {
 		buttonLikedBackground,
 		buttonFocusOutline,
 		buttonErrorBorder,
+		ctaText,
+		reactionEmoji,
 	} = attributes;
 
 	const style = {};
@@ -101,6 +103,32 @@ function Edit( { attributes, setAttributes } ) {
 							setAttributes( { buttonSize: value } )
 						}
 					/>
+					<TextControl
+						label={ __( 'CTA Message', 'child' ) }
+						value={ ctaText }
+						onChange={ ( value ) => setAttributes( { ctaText: value } ) }
+						help={ __(
+							'Short prompt shown before the emoji and like count.',
+							'child'
+						) }
+					/>
+					<SelectControl
+						label={ __( 'Emoji', 'child' ) }
+						value={ reactionEmoji }
+						options={ [
+							{ label: '❤️ Heart', value: '❤️' },
+							{ label: '💖 Sparkling Heart', value: '💖' },
+							{ label: '👍 Thumbs Up', value: '👍' },
+							{ label: '🔥 Fire', value: '🔥' },
+							{ label: '😂 Laugh', value: '😂' },
+							{ label: '🎉 Party', value: '🎉' },
+							{ label: '🍰 Cake', value: '🍰' },
+							{ label: '⭐ Star', value: '⭐' },
+						] }
+						onChange={ ( value ) =>
+							setAttributes( { reactionEmoji: value } )
+						}
+					/>
 				</PanelBody>
 				<PanelColorSettings
 					title={ __( 'Button Colors', 'child' ) }
@@ -155,8 +183,9 @@ function Edit( { attributes, setAttributes } ) {
 				className="child-post-likes__button is-editor-preview"
 				disabled
 			>
+				<span className="child-post-likes__cta">{ ctaText }</span>
 				<span className="child-post-likes__icon" aria-hidden="true">
-					❤
+					{ reactionEmoji }
 				</span>
 				<span className="child-post-likes__count">0</span>
 			</button>

--- a/blocks/post-likes/render.php
+++ b/blocks/post-likes/render.php
@@ -81,7 +81,6 @@ return function( array $attributes ): string {
 		: get_block_wrapper_attributes();
 	$cta_text           = $attributes['ctaText'] ?? 'Do you like this?';
 	$cta_text           = is_string( $cta_text ) ? trim( wp_strip_all_tags( $cta_text ) ) : 'Do you like this?';
-	$cta_text           = $cta_text !== '' ? $cta_text : 'Do you like this?';
 	$reaction_emoji     = $attributes['reactionEmoji'] ?? '❤️';
 	$reaction_emoji     = is_string( $reaction_emoji ) ? trim( wp_strip_all_tags( $reaction_emoji ) ) : '❤️';
 	$reaction_emoji     = $reaction_emoji !== '' ? $reaction_emoji : '❤️';
@@ -96,7 +95,9 @@ return function( array $attributes ): string {
 			aria-label="<?php esc_attr_e( 'Toggle like', 'child' ); ?>"
 			aria-pressed="<?php echo $liked ? 'true' : 'false'; ?>"
 		>
-			<span class="child-post-likes__cta"><?php echo esc_html( $cta_text ); ?></span>
+			<?php if ( $cta_text !== '' ) : ?>
+				<span class="child-post-likes__cta"><?php echo esc_html( $cta_text ); ?></span>
+			<?php endif; ?>
 			<span class="child-post-likes__icon" aria-hidden="true"><?php echo esc_html( $reaction_emoji ); ?></span>
 			<span class="child-post-likes__count"><?php echo esc_html( (string) $count ); ?></span>
 		</button>

--- a/blocks/post-likes/render.php
+++ b/blocks/post-likes/render.php
@@ -98,8 +98,10 @@ return function( array $attributes ): string {
 			<?php if ( $cta_text !== '' ) : ?>
 				<span class="child-post-likes__cta"><?php echo esc_html( $cta_text ); ?></span>
 			<?php endif; ?>
-			<span class="child-post-likes__icon" aria-hidden="true"><?php echo esc_html( $reaction_emoji ); ?></span>
-			<span class="child-post-likes__count"><?php echo esc_html( (string) $count ); ?></span>
+			<span class="child-post-likes__pill">
+				<span class="child-post-likes__icon" aria-hidden="true"><?php echo esc_html( $reaction_emoji ); ?></span>
+				<span class="child-post-likes__count"><?php echo esc_html( (string) $count ); ?></span>
+			</span>
 		</button>
 	</div>
 	<?php

--- a/blocks/post-likes/render.php
+++ b/blocks/post-likes/render.php
@@ -79,6 +79,12 @@ return function( array $attributes ): string {
 	$wrapper_attributes = $style_string
 		? get_block_wrapper_attributes( [ 'style' => $style_string ] )
 		: get_block_wrapper_attributes();
+	$cta_text           = $attributes['ctaText'] ?? 'Do you like this?';
+	$cta_text           = is_string( $cta_text ) ? trim( wp_strip_all_tags( $cta_text ) ) : 'Do you like this?';
+	$cta_text           = $cta_text !== '' ? $cta_text : 'Do you like this?';
+	$reaction_emoji     = $attributes['reactionEmoji'] ?? '❤️';
+	$reaction_emoji     = is_string( $reaction_emoji ) ? trim( wp_strip_all_tags( $reaction_emoji ) ) : '❤️';
+	$reaction_emoji     = $reaction_emoji !== '' ? $reaction_emoji : '❤️';
 
 	ob_start();
 	?>
@@ -90,7 +96,8 @@ return function( array $attributes ): string {
 			aria-label="<?php esc_attr_e( 'Toggle like', 'child' ); ?>"
 			aria-pressed="<?php echo $liked ? 'true' : 'false'; ?>"
 		>
-			<span class="child-post-likes__icon" aria-hidden="true">❤</span>
+			<span class="child-post-likes__cta"><?php echo esc_html( $cta_text ); ?></span>
+			<span class="child-post-likes__icon" aria-hidden="true"><?php echo esc_html( $reaction_emoji ); ?></span>
 			<span class="child-post-likes__count"><?php echo esc_html( (string) $count ); ?></span>
 		</button>
 	</div>

--- a/blocks/post-likes/style.css
+++ b/blocks/post-likes/style.css
@@ -48,6 +48,10 @@
 	font-size: 1.1em;
 }
 
+.wp-block-child-post-likes .child-post-likes__cta {
+	font-weight: 600;
+}
+
 .wp-block-child-post-likes .child-post-likes__count {
 	font-size: 1.1em;
 	min-width: 1ch;

--- a/blocks/post-likes/style.css
+++ b/blocks/post-likes/style.css
@@ -6,13 +6,27 @@
 .wp-block-child-post-likes .child-post-likes__button {
 	align-items: center;
 	appearance: none;
-	background: var(--child-post-likes-bg, #14060f);
-	border: 1px solid var(--child-post-likes-border, #4f1630);
-	border-radius: 999px;
+	background: transparent;
+	border: 0;
 	color: var(--child-post-likes-text, #ff5a8b);
 	cursor: pointer;
 	display: inline-flex;
 	font-size: var(--child-post-likes-font-size, 1rem);
+	font-weight: 600;
+	gap: 0.8rem;
+	line-height: 1;
+	padding: 0;
+	transition: color 0.2s ease;
+}
+
+.wp-block-child-post-likes .child-post-likes__pill {
+	align-items: center;
+	background: var(--child-post-likes-bg, #14060f);
+	border: 1px solid var(--child-post-likes-border, #4f1630);
+	border-radius: 999px;
+	color: var(--child-post-likes-text, #ff5a8b);
+	display: inline-flex;
+	font-size: 1em;
 	font-weight: 700;
 	gap: 0.6rem;
 	line-height: 1;
@@ -21,7 +35,7 @@
 	transition: transform 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
 }
 
-.wp-block-child-post-likes .child-post-likes__button:hover {
+.wp-block-child-post-likes .child-post-likes__button:hover .child-post-likes__pill {
 	border-color: var(--child-post-likes-hover-border, #ff5a8b);
 	transform: translateY(-1px);
 }
@@ -31,7 +45,7 @@
 	outline-offset: 2px;
 }
 
-.wp-block-child-post-likes .child-post-likes__button.is-liked {
+.wp-block-child-post-likes .child-post-likes__button.is-liked .child-post-likes__pill {
 	background: var(--child-post-likes-liked-bg, #2a0a1b);
 	border-color: var(--child-post-likes-hover-border, #ff5a8b);
 }
@@ -40,7 +54,7 @@
 	opacity: 0.8;
 }
 
-.wp-block-child-post-likes .child-post-likes__button.has-error {
+.wp-block-child-post-likes .child-post-likes__button.has-error .child-post-likes__pill {
 	border-color: var(--child-post-likes-error-border, #ff9ab6);
 }
 


### PR DESCRIPTION
### Motivation
- Provide a richer, customizable reaction UI so authors can show a short CTA prompt and pick an emoji reaction instead of a fixed heart. 
- Allow editor authors to author content patterns like `Do you like cake too? 🍰 1` directly from the block controls. 

### Description
- Added `ctaText` and `reactionEmoji` attributes to the block schema (`blocks/post-likes/block.json`) with safe defaults. 
- Extended the block editor UI (`blocks/post-likes/index.js`) with a `TextControl` for the CTA and a `SelectControl` emoji picker, and updated the editor preview to render `CTA + emoji + count`. 
- Updated server-side rendering (`blocks/post-likes/render.php`) to output the CTA and selected emoji with sanitization and fallbacks so the frontend matches the editor. 
- Added simple styling for the CTA (`blocks/post-likes/style.css`) so the prompt displays clearly next to the emoji and count. 

### Testing
- Ran the build with `npm run build`, which completed successfully and produced a successful webpack compilation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c820bac4dc8325ba28c4c5e155bd49)