### PR TITLE
Add Apple MusicKit Gutenberg block with feasibility proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A production-focused child theme for **Twenty Twenty-Five** that keeps customiza
 
 ## Dynamic Blocks Registered
 
+- `child/apple-music-player`
 - `child/book-rating`
 - `child/magic-cards`
 - `child/media-recommendation`

--- a/blocks/apple-music-player/block.json
+++ b/blocks/apple-music-player/block.json
@@ -1,0 +1,34 @@
+{
+  "apiVersion": 3,
+  "name": "child/apple-music-player",
+  "title": "Apple Music Player",
+  "category": "widgets",
+  "icon": "format-audio",
+  "description": "Embeds a MusicKit-powered Apple Music player for a song, album, or playlist.",
+  "supports": {
+    "html": false
+  },
+  "attributes": {
+    "resourceType": {
+      "type": "string",
+      "default": "song"
+    },
+    "resourceId": {
+      "type": "string",
+      "default": ""
+    },
+    "storefront": {
+      "type": "string",
+      "default": "us"
+    },
+    "buttonLabel": {
+      "type": "string",
+      "default": "Play on Apple Music"
+    }
+  },
+  "textdomain": "twentyfivetwentyfivechild",
+  "editorScript": "file:./index.js",
+  "viewScript": "file:./view.js",
+  "editorStyle": "file:./editor.css",
+  "style": "file:./style.css"
+}

--- a/blocks/apple-music-player/editor.css
+++ b/blocks/apple-music-player/editor.css
@@ -1,0 +1,4 @@
+.wp-block-child-apple-music-player {
+	outline: 1px dashed color-mix(in srgb, currentColor 35%, transparent);
+	outline-offset: 4px;
+}

--- a/blocks/apple-music-player/index.js
+++ b/blocks/apple-music-player/index.js
@@ -1,0 +1,80 @@
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, SelectControl, TextControl } from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
+import metadata from './block.json';
+import './editor.css';
+import './style.css';
+
+function Edit( { attributes, setAttributes } ) {
+	const {
+		resourceType = 'song',
+		resourceId = '',
+		storefront = 'us',
+		buttonLabel = 'Play on Apple Music',
+	} = attributes;
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Apple Music Settings', 'child' ) }>
+					<SelectControl
+						label={ __( 'Resource type', 'child' ) }
+						value={ resourceType }
+						options={ [
+							{ label: __( 'Song', 'child' ), value: 'song' },
+							{ label: __( 'Album', 'child' ), value: 'album' },
+							{ label: __( 'Playlist', 'child' ), value: 'playlist' },
+						] }
+						onChange={ ( value ) => setAttributes( { resourceType: value } ) }
+					/>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Apple Music resource ID', 'child' ) }
+						value={ resourceId }
+						onChange={ ( value ) => setAttributes( { resourceId: value.trim() } ) }
+						help={ __(
+							'For example: 310730204 (song), 1560735414 (album), or pl.u-xxxx (playlist).',
+							'child'
+						) }
+					/>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Storefront', 'child' ) }
+						value={ storefront }
+						onChange={ ( value ) => setAttributes( { storefront: value.trim().toLowerCase() } ) }
+						help={ __( 'Two-letter storefront code (for example: us, gb, de).', 'child' ) }
+					/>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Button label', 'child' ) }
+						value={ buttonLabel }
+						onChange={ ( value ) => setAttributes( { buttonLabel: value } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<div { ...useBlockProps() }>
+				{ resourceId ? (
+					<ServerSideRender block={ metadata.name } attributes={ attributes } />
+				) : (
+					<p>
+						{ __(
+							'Add an Apple Music resource ID in block settings to render the player.',
+							'child'
+						) }
+					</p>
+				) }
+			</div>
+		</>
+	);
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/blocks/apple-music-player/render.php
+++ b/blocks/apple-music-player/render.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Render Apple Music Player block.
+ *
+ * @return callable
+ */
+
+return function( $attributes ) {
+	$resource_type = isset( $attributes['resourceType'] ) ? sanitize_key( (string) $attributes['resourceType'] ) : 'song';
+	$allowed_types = [ 'song', 'album', 'playlist' ];
+	if ( ! in_array( $resource_type, $allowed_types, true ) ) {
+		$resource_type = 'song';
+	}
+
+	$resource_id = isset( $attributes['resourceId'] ) ? trim( (string) $attributes['resourceId'] ) : '';
+	$storefront = isset( $attributes['storefront'] ) ? sanitize_key( (string) $attributes['storefront'] ) : 'us';
+	$button_label = isset( $attributes['buttonLabel'] ) ? trim( (string) $attributes['buttonLabel'] ) : '';
+
+	if ( '' === $button_label ) {
+		$button_label = __( 'Play on Apple Music', 'child' );
+	}
+
+	if ( '' === $resource_id ) {
+		return '';
+	}
+
+	$music_kit_config = apply_filters(
+		'child_music_kit_config',
+		[
+			'developerToken' => '',
+			'appName'        => get_bloginfo( 'name' ),
+			'appBuild'       => '1.0.0',
+		]
+	);
+
+	$developer_token = '';
+	if ( is_array( $music_kit_config ) && isset( $music_kit_config['developerToken'] ) ) {
+		$developer_token = trim( (string) $music_kit_config['developerToken'] );
+	}
+
+	if ( '' === $developer_token ) {
+		return sprintf(
+			'<p %s>%s</p>',
+			get_block_wrapper_attributes(),
+			esc_html__( 'Apple Music Player is not configured yet. Add a MusicKit developer token via the child_music_kit_config filter.', 'child' )
+		);
+	}
+
+	wp_enqueue_script(
+		'child-musickit-sdk',
+		'https://js-cdn.music.apple.com/musickit/v3/musickit.js',
+		[],
+		null,
+		true
+	);
+
+	$app_name = is_array( $music_kit_config ) && isset( $music_kit_config['appName'] )
+		? trim( (string) $music_kit_config['appName'] )
+		: get_bloginfo( 'name' );
+	$app_build = is_array( $music_kit_config ) && isset( $music_kit_config['appBuild'] )
+		? trim( (string) $music_kit_config['appBuild'] )
+		: '1.0.0';
+
+	ob_start();
+	?>
+	<div <?php echo get_block_wrapper_attributes(); ?>>
+		<div
+			class="child-apple-music-player"
+			data-developer-token="<?php echo esc_attr( $developer_token ); ?>"
+			data-app-name="<?php echo esc_attr( $app_name ); ?>"
+			data-app-build="<?php echo esc_attr( $app_build ); ?>"
+			data-storefront="<?php echo esc_attr( $storefront ); ?>"
+			data-resource-type="<?php echo esc_attr( $resource_type ); ?>"
+			data-resource-id="<?php echo esc_attr( $resource_id ); ?>"
+		>
+			<button type="button" class="child-apple-music-player__button">
+				<?php echo esc_html( $button_label ); ?>
+			</button>
+			<p class="child-apple-music-player__status" aria-live="polite"></p>
+		</div>
+	</div>
+	<?php
+
+	return ob_get_clean();
+};

--- a/blocks/apple-music-player/style.css
+++ b/blocks/apple-music-player/style.css
@@ -1,0 +1,29 @@
+.wp-block-child-apple-music-player .child-apple-music-player {
+	padding: 1rem;
+	border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
+	border-radius: 0.75rem;
+	display: grid;
+	gap: 0.75rem;
+	max-width: 28rem;
+}
+
+.wp-block-child-apple-music-player .child-apple-music-player__button {
+	padding: 0.7rem 1rem;
+	border-radius: 999px;
+	border: none;
+	font-weight: 600;
+	cursor: pointer;
+	background: #fa233b;
+	color: #fff;
+}
+
+.wp-block-child-apple-music-player .child-apple-music-player__button:disabled {
+	opacity: 0.75;
+	cursor: wait;
+}
+
+.wp-block-child-apple-music-player .child-apple-music-player__status {
+	margin: 0;
+	font-size: 0.92rem;
+	opacity: 0.85;
+}

--- a/blocks/apple-music-player/view.js
+++ b/blocks/apple-music-player/view.js
@@ -1,0 +1,94 @@
+const PLAYER_SELECTOR = '.wp-block-child-apple-music-player .child-apple-music-player';
+
+const state = {
+	configured: false,
+};
+
+const setStatus = ( element, message ) => {
+	const status = element.querySelector( '.child-apple-music-player__status' );
+	if ( status ) {
+		status.textContent = message;
+	}
+};
+
+const queueFromDataset = ( dataset ) => {
+	if ( dataset.resourceType === 'album' ) {
+		return { album: dataset.resourceId };
+	}
+
+	if ( dataset.resourceType === 'playlist' ) {
+		return { playlist: dataset.resourceId };
+	}
+
+	return { song: dataset.resourceId };
+};
+
+const configureMusicKit = ( element ) => {
+	if ( state.configured ) {
+		return;
+	}
+
+	if ( ! window.MusicKit || typeof window.MusicKit.configure !== 'function' ) {
+		throw new Error( 'MusicKit JS failed to load.' );
+	}
+
+	window.MusicKit.configure( {
+		developerToken: element.dataset.developerToken,
+		app: {
+			name: element.dataset.appName || 'WordPress Apple Music Player',
+			build: element.dataset.appBuild || '1.0.0',
+		},
+	} );
+
+	state.configured = true;
+};
+
+const handlePlay = async ( event ) => {
+	const button = event.currentTarget;
+	const element = button.closest( '.child-apple-music-player' );
+
+	if ( ! element ) {
+		return;
+	}
+
+	button.disabled = true;
+	setStatus( element, 'Loading Apple Music playback…' );
+
+	try {
+		configureMusicKit( element );
+		const music = window.MusicKit.getInstance();
+		await music.setQueue( queueFromDataset( element.dataset ) );
+		await music.play();
+		setStatus( element, 'Now playing.' );
+	} catch ( error ) {
+		setStatus(
+			element,
+			'Playback failed. Ensure MusicKit developer token and Apple Music entitlements are configured.'
+		);
+	} finally {
+		button.disabled = false;
+	}
+};
+
+const initAppleMusicPlayerBlocks = () => {
+	const elements = document.querySelectorAll( PLAYER_SELECTOR );
+	if ( ! elements.length ) {
+		return;
+	}
+
+	elements.forEach( ( element ) => {
+		const button = element.querySelector( '.child-apple-music-player__button' );
+		if ( ! button || button.dataset.ready === '1' ) {
+			return;
+		}
+
+		button.dataset.ready = '1';
+		button.addEventListener( 'click', handlePlay );
+	} );
+};
+
+if ( document.readyState === 'loading' ) {
+	document.addEventListener( 'DOMContentLoaded', initAppleMusicPlayerBlocks, { once: true } );
+} else {
+	initAppleMusicPlayerBlocks();
+}

--- a/blocks/index.js
+++ b/blocks/index.js
@@ -1,3 +1,4 @@
+import './apple-music-player';
 import './popular-posts';
 import './visual-link-preview';
 import './book-rating';

--- a/docs/apple-music-block-proposal.md
+++ b/docs/apple-music-block-proposal.md
@@ -1,0 +1,39 @@
+# Proposal: Gutenberg Apple MusicKit Block
+
+## Goal
+Create a Gutenberg block that can play an Apple Music song, album, or playlist using MusicKit JS v3.
+
+## Feasibility for WordPress
+This is feasible in WordPress as a dynamic block with a frontend `view.js` script. The main technical constraint is **MusicKit authentication**:
+
+1. A valid Apple MusicKit developer token must be generated server-side (Apple Developer account required).
+2. Token lifecycle needs operational handling (rotation before expiry).
+3. Some playback behavior may require user authorization in Apple Music depending on entitlement and account state.
+
+## Proposed Architecture
+1. Gutenberg block (`child/apple-music-player`) with attributes:
+   - `resourceType` (`song|album|playlist`)
+   - `resourceId`
+   - `storefront`
+   - `buttonLabel`
+2. PHP render callback outputs semantic markup + data attributes and enqueues `https://js-cdn.music.apple.com/musickit/v3/musickit.js`.
+3. Frontend `view.js` configures MusicKit once and triggers queue/play on button click.
+4. Configuration hook in PHP filter `child_music_kit_config` for `developerToken`, `appName`, and `appBuild`.
+
+## Security and Ops Notes
+- Developer token is present client-side by design with MusicKit JS.
+- Use short-lived tokens and rotation automation.
+- Never hardcode private key material in the theme.
+
+## Example Theme-Level Configuration
+```php
+add_filter( 'child_music_kit_config', static function( array $config ): array {
+	$config['developerToken'] = 'YOUR_SHORT_LIVED_MUSICKIT_TOKEN';
+	$config['appName'] = 'My WP Site';
+	$config['appBuild'] = '1.0.0';
+	return $config;
+} );
+```
+
+## Implementation Status
+A first-pass block implementation is included in this repository under `blocks/apple-music-player` and registered as a dynamic block.

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -12,6 +12,10 @@
  */
 function child_get_dynamic_blocks(): array {
 	return [
+		'apple-music-player'       => [
+			'block_name'  => 'child/apple-music-player',
+			'render_file' => 'blocks/apple-music-player/render.php',
+		],
 		'book-rating'              => [
 			'block_name'  => 'child/book-rating',
 			'render_file' => 'blocks/book-rating/render.php',


### PR DESCRIPTION
### Motivation
- Provide a Gutenberg block that embeds an Apple Music player using MusicKit JS v3 so editors can add song/album/playlist playback to posts and pages.
- Surface a configuration hook so sites can provide a MusicKit developer token and app metadata without hardcoding private keys in the theme.
- Document operational constraints around MusicKit authentication, token rotation, and entitlements for maintainers.

### Description
- Add a new dynamic block `child/apple-music-player` with editor metadata (`blocks/apple-music-player/block.json`) and editor UI (`blocks/apple-music-player/index.js`).
- Implement server-side rendering and configuration via `blocks/apple-music-player/render.php`, which enqueues the MusicKit SDK and exposes a `child_music_kit_config` filter for `developerToken`, `appName`, and `appBuild`.
- Add frontend playback wiring in `blocks/apple-music-player/view.js` and styles in `blocks/apple-music-player/style.css` and `blocks/apple-music-player/editor.css` to configure MusicKit and handle queue/play actions from block data attributes.
- Register the block in the central registry (`inc/blocks.php`) and include it in the block entrypoint (`blocks/index.js`), and add a feasibility/implementation document at `docs/apple-music-block-proposal.md` with README updates.

### Testing
- Built block assets with `npm run build`, which completed successfully and produced a `apple-music-player` asset chunk.
- Verified PHP syntax for the new render callback with `php -l blocks/apple-music-player/render.php`, which reported no syntax errors.
- Verified PHP syntax for the updated registry with `php -l inc/blocks.php`, which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cede7d49588325bb245728d69e3c53)