### PR TITLE
Register 'Feature Navigation' block style and add corresponding CSS

### DIFF
--- a/inc/navigation-feature-style.php
+++ b/inc/navigation-feature-style.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Optional feature navigation block style.
+ *
+ * @package TwentyTwentyFiveChild
+ */
+
+/**
+ * Register the opt-in block style for core/navigation.
+ */
+function child_register_navigation_feature_block_style(): void {
+	register_block_style(
+		'core/navigation',
+		[
+			'name'  => 'child-feature-nav',
+			'label' => __( 'Feature Navigation', 'child' ),
+		]
+	);
+}
+add_action( 'init', 'child_register_navigation_feature_block_style' );

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ Description: Child theme for TwentyTwentyFive with plugin replacements.
 Author: Niklas Barning
 Author URI: https://github.com/barning
 Template: twentytwentyfive
- Version: 1.2.2
+ Version: 1.2.3
 */
 
 .overflow-image {

--- a/style.css
+++ b/style.css
@@ -18,3 +18,56 @@ Template: twentytwentyfive
 	box-shadow: var(--wp--preset--shadow--deep);
 	translate: 0 -2px 0;
 }
+
+.wp-block-navigation.is-style-child-feature-nav {
+	position: sticky;
+	top: clamp(0.5rem, 2vw, 1rem);
+	z-index: 40;
+	display: flex;
+	align-items: center;
+	gap: 1rem;
+	padding: 0.75rem 1rem;
+	border: 1px solid color-mix(in srgb, currentColor 14%, transparent);
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--wp--preset--color--base, #ffffff) 80%, transparent);
+	backdrop-filter: blur(12px);
+	width: fit-content;
+	max-width: 100%;
+}
+
+.wp-block-navigation.is-style-child-feature-nav .wp-block-navigation__container {
+	gap: 0.85rem;
+}
+
+.wp-block-navigation.is-style-child-feature-nav .wp-block-navigation-item__content {
+	position: relative;
+	font-size: 0.92rem;
+	letter-spacing: 0.02em;
+	text-decoration: none;
+}
+
+.wp-block-navigation.is-style-child-feature-nav .wp-block-navigation-item__content::after {
+	content: '';
+	position: absolute;
+	left: 0;
+	bottom: -0.25rem;
+	width: 100%;
+	height: 1px;
+	background: currentColor;
+	transform: scaleX(0);
+	transform-origin: left;
+	transition: transform 0.2s ease;
+}
+
+.wp-block-navigation.is-style-child-feature-nav .wp-block-navigation-item__content:hover::after,
+.wp-block-navigation.is-style-child-feature-nav .wp-block-navigation-item__content:focus-visible::after,
+.wp-block-navigation.is-style-child-feature-nav .wp-block-navigation-item__content[aria-current='page']::after {
+	transform: scaleX(1);
+}
+
+@media (max-width: 781px) {
+	.wp-block-navigation.is-style-child-feature-nav {
+		width: 100%;
+		justify-content: space-between;
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide an optional pill-style "Feature Navigation" block style for `core/navigation` so themes can opt-in to a sticky, blurred, feature-like navigation appearance.

### Description
- Added `inc/navigation-feature-style.php` which registers the block style `child-feature-nav` for `core/navigation` with the label "Feature Navigation".
- Updated `style.css` to include `.wp-block-navigation.is-style-child-feature-nav` rules implementing sticky positioning, blurred backdrop, pill border/background, item hover/underline effects, spacing adjustments, and a responsive layout for small viewports.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51ab1a288832585b83b1b356ffd6b)