### PR TITLE
Update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -20,28 +20,28 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build and package
         run: npm run dist
 
       - name: Upload artifact (theme folder)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: twentytwentyfive-child
           path: dist/twentytwentyfive-child/
 
       - name: Upload artifact (zip)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: twentytwentyfive-child-zip
           path: dist/twentytwentyfive-child.zip
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: twentytwentyfive-child-zip
 
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: twentytwentyfive-child-zip
 


### PR DESCRIPTION
### Motivation
- Prepare the build and release workflow for the upcoming Node.js 24 runner by upgrading first-party actions and the workflow Node runtime.  

### Description
- Bump `actions/checkout` to `@v6` and `actions/setup-node` to `@v6` and set `node-version` to `24`.  
- Replace `actions/upload-artifact@v4` and `actions/download-artifact@v4` with `@v7`.  
- Use deterministic dependency installation by changing `run: npm install` to `run: npm ci`.  

### Testing
- Verified runner Node version with `node -v` showing a Node 24 runtime.  
- Ran `npm ci && npm run dist` which completed the build (Webpack compiled successfully) and produced `dist/twentytwentyfive-child.zip`.  
- Confirmed the updated action tags exist using `git ls-remote` checks for the selected `v6`/`v7` tags.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05babeed1c83259f794438a26c1bac)