### PR TITLE
Refactor theme build and release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -6,12 +6,14 @@ on:
     tags: [ 'v*' ]
   pull_request:
     branches: [ main ]
-  release:
-    types: [ published ]
   workflow_dispatch: {}
 
 permissions:
-  contents: write  # Required for creating releases and uploading assets
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -25,8 +27,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
-          cache: 'npm'
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci
@@ -34,56 +37,33 @@ jobs:
       - name: Build and package
         run: npm run dist
 
-      - name: Upload artifact (theme folder)
-        uses: actions/upload-artifact@v7
-        with:
-          name: twentytwentyfive-child
-          path: dist/twentytwentyfive-child/
-
-      - name: Upload artifact (zip)
+      - name: Upload release package
         uses: actions/upload-artifact@v7
         with:
           name: twentytwentyfive-child-zip
           path: dist/twentytwentyfive-child.zip
+          if-no-files-found: error
+          retention-days: 14
 
   release:
-    # Creates a new GitHub release when a tag is pushed
+    # Tag pushes are the single release path. Published-release events are intentionally
+    # not handled here to avoid duplicate builds/uploads for the same version.
     if: startsWith(github.ref, 'refs/tags/v')
     needs: build
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
-      - name: Download artifact
+      - name: Download release package
         uses: actions/download-artifact@v7
         with:
           name: twentytwentyfive-child-zip
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
-          files: |
-            twentytwentyfive-child.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  upload-to-release:
-    # Uploads build to an existing release that was manually published
-    if: github.event_name == 'release'
-    needs: build
-    name: Upload Build to Release
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: twentytwentyfive-child-zip
-
-      - name: Upload to Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            twentytwentyfive-child.zip
+          files: twentytwentyfive-child.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation
- Reduce risk by applying least-privilege `GITHUB_TOKEN` permissions and granting write only where required for releases.
- Avoid duplicate release paths and accidental double-uploads by using a single tag-driven release flow.
- Improve workflow reliability and performance with concurrency and lockfile-aware Node caching.
- Make artifact handling deterministic and limit artifact retention to reduce storage footprint.

### Description
- Scoped default workflow `permissions` to `contents: read` and granted `contents: write` only in the release job via job-level `permissions`.
- Removed the `release: published` trigger and the separate `upload-to-release` job, keeping tag pushes (refs/tags/v*) as the single release path.
- Added `concurrency` to cancel in-progress runs for the same branch/tag and avoid duplicate work.
- Updated `setup-node` to use `node-version-file: .nvmrc`, enabled `cache: npm` with `cache-dependency-path: package-lock.json`, and simplified artifact upload to only the release zip with `if-no-files-found: error` and `retention-days: 14`.
- Upgraded `softprops/action-gh-release` usage to the current major (`v3`) and normalized `actions/upload-artifact`/`actions/download-artifact` usage.

### Testing
- Ran `npm run dist` which completed successfully and produced `dist/twentytwentyfive-child.zip`.
- Validated workflow syntax with `actionlint` using the official installer and binary, which reported no issues.
- Ran `git diff --check` to ensure no whitespace or diff errors, which returned clean results.
- Attempted `npx --yes actionlint` which failed due to the environment's npm executable resolution, but validation was completed with the downloaded `actionlint` binary successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19e996a1a483258df000037b57a060)