### PR TITLE
Add `media-cover-grid` dynamic block with server render and helpers

### DIFF
--- a/blocks/index.js
+++ b/blocks/index.js
@@ -3,6 +3,7 @@ import './visual-link-preview';
 import './book-rating';
 import './magic-cards';
 import './media-recommendation'; // Ensure consistency with other blocks by registering here
+import './media-cover-grid';
 import './videogame-recommendation';
 import './pixelfed-feed';
 

--- a/blocks/media-cover-grid/block.json
+++ b/blocks/media-cover-grid/block.json
@@ -1,0 +1,50 @@
+{
+  "apiVersion": 3,
+  "name": "child/media-cover-grid",
+  "title": "Medien-Cover-Grid",
+  "category": "widgets",
+  "icon": "screenoptions",
+  "description": "Zeigt automatisch Cover aus Buch-, Film/Serien- und Videospiel-Blöcken in veröffentlichten Beiträgen.",
+  "supports": {
+    "html": false,
+    "align": ["wide", "full"]
+  },
+  "attributes": {
+    "mediaTypes": {
+      "type": "array",
+      "default": ["book", "movie", "tv", "game"]
+    },
+    "maxItems": {
+      "type": "number",
+      "default": 48
+    },
+    "linkTo": {
+      "type": "string",
+      "default": "post"
+    },
+    "sortOrder": {
+      "type": "string",
+      "default": "newest"
+    },
+    "showTitle": {
+      "type": "boolean",
+      "default": true
+    },
+    "showMeta": {
+      "type": "boolean",
+      "default": true
+    },
+    "showType": {
+      "type": "boolean",
+      "default": true
+    },
+    "allowDuplicates": {
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "textdomain": "twentyfivetwentyfivechild",
+  "editorScript": "file:./index.js",
+  "editorStyle": "file:./editor.css",
+  "style": "file:./style.css"
+}

--- a/blocks/media-cover-grid/editor.css
+++ b/blocks/media-cover-grid/editor.css
@@ -1,0 +1,35 @@
+.wp-block-child-media-cover-grid .child-media-cover-grid__editor-note,
+.child-media-cover-grid-block .child-media-cover-grid__editor-note {
+  background: color-mix(in srgb, currentColor 8%, transparent);
+  border-radius: 10px;
+  font-size: 0.9rem;
+  margin-block-end: 1rem;
+  padding: 0.75rem 1rem;
+}
+
+.wp-block-child-media-cover-grid .child-media-cover-grid__cover,
+.child-media-cover-grid-block .child-media-cover-grid__cover {
+  background: linear-gradient(135deg, #f2f0ec, #d7d1c8);
+}
+
+.wp-block-child-media-cover-grid .child-media-cover-grid__cover span,
+.child-media-cover-grid-block .child-media-cover-grid__cover span {
+  color: #5c5348;
+  font-size: 3rem;
+  font-weight: 800;
+}
+
+.wp-block-child-media-cover-grid .child-media-cover-grid__cover--movie,
+.child-media-cover-grid-block .child-media-cover-grid__cover--movie {
+  background: linear-gradient(135deg, #ece7ff, #b6a7ff);
+}
+
+.wp-block-child-media-cover-grid .child-media-cover-grid__cover--tv,
+.child-media-cover-grid-block .child-media-cover-grid__cover--tv {
+  background: linear-gradient(135deg, #e3f4ff, #8bc4ee);
+}
+
+.wp-block-child-media-cover-grid .child-media-cover-grid__cover--game,
+.child-media-cover-grid-block .child-media-cover-grid__cover--game {
+  background: linear-gradient(135deg, #e6f8ec, #79d498);
+}

--- a/blocks/media-cover-grid/index.js
+++ b/blocks/media-cover-grid/index.js
@@ -1,0 +1,176 @@
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import {
+    PanelBody,
+    CheckboxControl,
+    RangeControl,
+    SelectControl,
+    ToggleControl
+} from '@wordpress/components';
+import metadata from './block.json';
+import './editor.css';
+import './style.css';
+
+const MEDIA_TYPE_OPTIONS = [
+    { value: 'book', label: __('Bücher', 'child') },
+    { value: 'movie', label: __('Filme', 'child') },
+    { value: 'tv', label: __('Serien', 'child') },
+    { value: 'game', label: __('Videospiele', 'child') }
+];
+
+const PREVIEW_ITEMS = [
+    {
+        type: 'book',
+        typeLabel: __('Buch', 'child'),
+        title: __('Beispielbuch', 'child'),
+        meta: __('Autor:in', 'child')
+    },
+    {
+        type: 'movie',
+        typeLabel: __('Film', 'child'),
+        title: __('Beispielfilm', 'child'),
+        meta: '2025'
+    },
+    {
+        type: 'tv',
+        typeLabel: __('Serie', 'child'),
+        title: __('Beispielserie', 'child'),
+        meta: '2024'
+    },
+    {
+        type: 'game',
+        typeLabel: __('Videospiel', 'child'),
+        title: __('Beispielspiel', 'child'),
+        meta: __('PC, Switch', 'child')
+    }
+];
+
+const updateMediaTypes = (mediaTypes, value, checked) => {
+    const normalizedTypes = Array.isArray(mediaTypes) ? mediaTypes : [];
+
+    if (checked) {
+        return [...new Set([...normalizedTypes, value])];
+    }
+
+    return normalizedTypes.filter((type) => type !== value);
+};
+
+function Edit({ attributes, setAttributes }) {
+    const {
+        mediaTypes = metadata.attributes.mediaTypes.default,
+        maxItems = metadata.attributes.maxItems.default,
+        linkTo = metadata.attributes.linkTo.default,
+        sortOrder = metadata.attributes.sortOrder.default,
+        showTitle = true,
+        showMeta = true,
+        showType = true,
+        allowDuplicates = false
+    } = attributes;
+
+    const blockProps = useBlockProps({ className: 'child-media-cover-grid-block' });
+    const enabledTypes = Array.isArray(mediaTypes) ? mediaTypes : [];
+    const previewItems = PREVIEW_ITEMS.filter((item) => enabledTypes.includes(item.type));
+
+    return (
+        <div {...blockProps}>
+            <InspectorControls>
+                <PanelBody title={__('Medien filtern', 'child')} initialOpen={true}>
+                    {MEDIA_TYPE_OPTIONS.map((option) => (
+                        <CheckboxControl
+                            key={option.value}
+                            label={option.label}
+                            checked={enabledTypes.includes(option.value)}
+                            onChange={(checked) =>
+                                setAttributes({
+                                    mediaTypes: updateMediaTypes(enabledTypes, option.value, checked)
+                                })
+                            }
+                        />
+                    ))}
+                    <RangeControl
+                        label={__('Maximale Anzahl', 'child')}
+                        value={maxItems}
+                        onChange={(value) => setAttributes({ maxItems: value })}
+                        min={1}
+                        max={120}
+                    />
+                </PanelBody>
+
+                <PanelBody title={__('Darstellung', 'child')} initialOpen={true}>
+                    <SelectControl
+                        label={__('Sortierung', 'child')}
+                        value={sortOrder}
+                        options={[
+                            { label: __('Neueste Beiträge zuerst', 'child'), value: 'newest' },
+                            { label: __('Älteste Beiträge zuerst', 'child'), value: 'oldest' },
+                            { label: __('Titel A–Z', 'child'), value: 'title' }
+                        ]}
+                        onChange={(value) => setAttributes({ sortOrder: value })}
+                    />
+                    <SelectControl
+                        label={__('Links öffnen', 'child')}
+                        value={linkTo}
+                        options={[
+                            { label: __('Zum Beitrag', 'child'), value: 'post' },
+                            { label: __('Zum externen Medien-Link', 'child'), value: 'external' },
+                            { label: __('Kein Link', 'child'), value: 'none' }
+                        ]}
+                        onChange={(value) => setAttributes({ linkTo: value })}
+                    />
+                    <ToggleControl
+                        label={__('Titel anzeigen', 'child')}
+                        checked={showTitle}
+                        onChange={(value) => setAttributes({ showTitle: value })}
+                    />
+                    <ToggleControl
+                        label={__('Meta anzeigen', 'child')}
+                        checked={showMeta}
+                        onChange={(value) => setAttributes({ showMeta: value })}
+                    />
+                    <ToggleControl
+                        label={__('Typ anzeigen', 'child')}
+                        checked={showType}
+                        onChange={(value) => setAttributes({ showType: value })}
+                    />
+                    <ToggleControl
+                        label={__('Doppelte Einträge erlauben', 'child')}
+                        checked={allowDuplicates}
+                        onChange={(value) => setAttributes({ allowDuplicates: value })}
+                    />
+                </PanelBody>
+            </InspectorControls>
+
+            <div className="child-media-cover-grid__editor-note">
+                {__('Dieses Grid wird auf der Website automatisch aus veröffentlichten Beiträgen befüllt.', 'child')}
+            </div>
+            <div className="child-media-cover-grid">
+                {previewItems.length ? (
+                    previewItems.map((item) => (
+                        <div key={item.type} className="child-media-cover-grid__item">
+                            <div className={`child-media-cover-grid__cover child-media-cover-grid__cover--${item.type}`} aria-hidden="true">
+                                <span>{item.typeLabel.charAt(0)}</span>
+                            </div>
+                            {(showType || showTitle || showMeta) && (
+                                <div className="child-media-cover-grid__content">
+                                    {showType && <span className="child-media-cover-grid__type">{item.typeLabel}</span>}
+                                    {showTitle && <h3 className="child-media-cover-grid__title">{item.title}</h3>}
+                                    {showMeta && <p className="child-media-cover-grid__meta">{item.meta}</p>}
+                                </div>
+                            )}
+                        </div>
+                    ))
+                ) : (
+                    <p className="child-media-cover-grid__empty">
+                        {__('Wähle mindestens einen Medientyp aus.', 'child')}
+                    </p>
+                )}
+            </div>
+        </div>
+    );
+}
+
+registerBlockType(metadata.name, {
+    edit: Edit,
+    save: () => null
+});

--- a/blocks/media-cover-grid/index.js
+++ b/blocks/media-cover-grid/index.js
@@ -134,7 +134,8 @@ function Edit({ attributes, setAttributes }) {
                         onChange={(value) => setAttributes({ showType: value })}
                     />
                     <ToggleControl
-                        label={__('Doppelte Einträge erlauben', 'child')}
+                        label={__('Doppelte Erwähnungen einzeln anzeigen', 'child')}
+                        help={__('Ausgeschaltet: dasselbe Medium erscheint nur einmal, auch wenn es in mehreren Beiträgen erwähnt wird.', 'child')}
                         checked={allowDuplicates}
                         onChange={(value) => setAttributes({ allowDuplicates: value })}
                     />

--- a/blocks/media-cover-grid/render.php
+++ b/blocks/media-cover-grid/render.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Render Media Cover Grid Block.
+ *
+ * @package TwentyTwentyFiveChild
+ */
+
+return function( array $attributes ): string {
+	if ( ! function_exists( 'child_get_media_cover_grid_items' ) ) {
+		return '';
+	}
+
+	$default_types     = [ 'book', 'movie', 'tv', 'game' ];
+	$media_types       = $attributes['mediaTypes'] ?? $default_types;
+	$allowed_types     = array_values( array_intersect( $default_types, is_array( $media_types ) ? $media_types : $default_types ) );
+	$max_items         = max( 1, min( 120, absint( $attributes['maxItems'] ?? 48 ) ) );
+	$link_to           = in_array( $attributes['linkTo'] ?? 'post', [ 'post', 'external', 'none' ], true ) ? $attributes['linkTo'] : 'post';
+	$sort_order        = in_array( $attributes['sortOrder'] ?? 'newest', [ 'newest', 'oldest', 'title' ], true ) ? $attributes['sortOrder'] : 'newest';
+	$show_title        = (bool) ( $attributes['showTitle'] ?? true );
+	$show_meta         = (bool) ( $attributes['showMeta'] ?? true );
+	$show_type         = (bool) ( $attributes['showType'] ?? true );
+	$allow_duplicates  = (bool) ( $attributes['allowDuplicates'] ?? false );
+
+	if ( [] === $allowed_types ) {
+		return sprintf(
+			'<div %s><p class="child-media-cover-grid__empty">%s</p></div>',
+			get_block_wrapper_attributes( [ 'class' => 'child-media-cover-grid-block' ] ),
+			esc_html__( 'Bitte wähle mindestens einen Medientyp aus.', 'child' )
+		);
+	}
+
+	$items = child_get_media_cover_grid_items( $allow_duplicates );
+	$items = array_values(
+		array_filter(
+			$items,
+			static function( array $item ) use ( $allowed_types ): bool {
+				return in_array( $item['type'] ?? '', $allowed_types, true );
+			}
+		)
+	);
+
+	usort(
+		$items,
+		static function( array $a, array $b ) use ( $sort_order ): int {
+			if ( 'title' === $sort_order ) {
+				return strcasecmp( $a['title'] ?? '', $b['title'] ?? '' );
+			}
+
+			$a_time = (int) ( $a['sourcePostTimestamp'] ?? 0 );
+			$b_time = (int) ( $b['sourcePostTimestamp'] ?? 0 );
+
+			return 'oldest' === $sort_order ? $a_time <=> $b_time : $b_time <=> $a_time;
+		}
+	);
+
+	$items = array_slice( $items, 0, $max_items );
+
+	ob_start();
+	?>
+	<div <?php echo get_block_wrapper_attributes( [ 'class' => 'child-media-cover-grid-block' ] ); ?>>
+		<?php if ( [] === $items ) : ?>
+			<p class="child-media-cover-grid__empty"><?php echo esc_html__( 'Noch keine Medien gefunden.', 'child' ); ?></p>
+		<?php else : ?>
+			<div class="child-media-cover-grid" role="list">
+				<?php foreach ( $items as $item ) : ?>
+					<?php
+					$link_url     = '';
+					$link_target  = '';
+					$link_rel     = '';
+					$type         = (string) ( $item['type'] ?? '' );
+					$title        = (string) ( $item['title'] ?? '' );
+					$meta         = (string) ( $item['meta'] ?? '' );
+					$cover_url    = (string) ( $item['coverUrl'] ?? '' );
+					$type_label   = child_get_media_cover_grid_type_label( $type );
+					$source_title = (string) ( $item['sourcePostTitle'] ?? '' );
+
+					if ( 'post' === $link_to ) {
+						$link_url = (string) ( $item['sourcePostUrl'] ?? '' );
+					} elseif ( 'external' === $link_to && ! empty( $item['externalUrl'] ) ) {
+						$link_url    = (string) $item['externalUrl'];
+						$link_target = ' target="_blank"';
+						$link_rel    = ' rel="noopener noreferrer"';
+					}
+
+					$tag_name = $link_url ? 'a' : 'div';
+					?>
+					<<?php echo tag_escape( $tag_name ); ?> class="child-media-cover-grid__item child-media-cover-grid__item--<?php echo esc_attr( $type ); ?>"<?php echo $link_url ? ' href="' . esc_url( $link_url ) . '"' . $link_target . $link_rel : ''; ?> role="listitem" aria-label="<?php echo esc_attr( $title ); ?>">
+						<div class="child-media-cover-grid__cover">
+							<?php if ( $cover_url ) : ?>
+								<img src="<?php echo esc_url( $cover_url ); ?>" alt="<?php echo esc_attr( $title ); ?>" loading="lazy" />
+							<?php else : ?>
+								<span class="child-media-cover-grid__placeholder" aria-hidden="true"><?php echo esc_html( substr( $type_label, 0, 1 ) ); ?></span>
+							<?php endif; ?>
+						</div>
+
+						<?php if ( $show_type || $show_title || $show_meta ) : ?>
+							<div class="child-media-cover-grid__content">
+								<?php if ( $show_type ) : ?>
+									<span class="child-media-cover-grid__type"><?php echo esc_html( $type_label ); ?></span>
+								<?php endif; ?>
+								<?php if ( $show_title ) : ?>
+									<h3 class="child-media-cover-grid__title"><?php echo esc_html( $title ); ?></h3>
+								<?php endif; ?>
+								<?php if ( $show_meta && $meta ) : ?>
+									<p class="child-media-cover-grid__meta"><?php echo esc_html( $meta ); ?></p>
+								<?php endif; ?>
+								<?php if ( $show_meta && $source_title ) : ?>
+									<p class="child-media-cover-grid__source">
+										<?php
+										printf(
+											/* translators: %s: source post title */
+											esc_html__( 'Aus: %s', 'child' ),
+											esc_html( $source_title )
+										);
+										?>
+									</p>
+								<?php endif; ?>
+							</div>
+						<?php endif; ?>
+					</<?php echo tag_escape( $tag_name ); ?>>
+				<?php endforeach; ?>
+			</div>
+		<?php endif; ?>
+	</div>
+	<?php
+	return ob_get_clean();
+};

--- a/blocks/media-cover-grid/render.php
+++ b/blocks/media-cover-grid/render.php
@@ -72,7 +72,8 @@ return function( array $attributes ): string {
 					$meta         = (string) ( $item['meta'] ?? '' );
 					$cover_url    = (string) ( $item['coverUrl'] ?? '' );
 					$type_label   = child_get_media_cover_grid_type_label( $type );
-					$source_title = (string) ( $item['sourcePostTitle'] ?? '' );
+					$source_title  = (string) ( $item['sourcePostTitle'] ?? '' );
+					$mention_count = max( 1, absint( $item['mentionCount'] ?? 1 ) );
 
 					if ( 'post' === $link_to ) {
 						$link_url = (string) ( $item['sourcePostUrl'] ?? '' );
@@ -107,11 +108,19 @@ return function( array $attributes ): string {
 								<?php if ( $show_meta && $source_title ) : ?>
 									<p class="child-media-cover-grid__source">
 										<?php
-										printf(
-											/* translators: %s: source post title */
-											esc_html__( 'Aus: %s', 'child' ),
-											esc_html( $source_title )
-										);
+										if ( $mention_count > 1 ) {
+											printf(
+												/* translators: %d: number of source posts */
+												esc_html( _n( 'Erwähnt in %d Beitrag', 'Erwähnt in %d Beiträgen', $mention_count, 'child' ) ),
+												(int) $mention_count
+											);
+										} else {
+											printf(
+												/* translators: %s: source post title */
+												esc_html__( 'Aus: %s', 'child' ),
+												esc_html( $source_title )
+											);
+										}
 										?>
 									</p>
 								<?php endif; ?>

--- a/blocks/media-cover-grid/style.css
+++ b/blocks/media-cover-grid/style.css
@@ -1,0 +1,103 @@
+.wp-block-child-media-cover-grid,
+.child-media-cover-grid-block {
+  margin-block: 1.5rem;
+}
+
+.child-media-cover-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.child-media-cover-grid__item {
+  color: inherit;
+  display: block;
+  min-width: 0;
+  text-decoration: none;
+}
+
+.child-media-cover-grid__item:is(a):hover .child-media-cover-grid__cover,
+.child-media-cover-grid__item:is(a):focus-visible .child-media-cover-grid__cover {
+  box-shadow: 0 18px 35px color-mix(in srgb, currentColor 22%, transparent);
+  transform: translateY(-3px);
+}
+
+.child-media-cover-grid__item:is(a):focus-visible {
+  border-radius: 14px;
+  outline: 3px solid color-mix(in srgb, var(--wp--preset--color--contrast, currentColor) 55%, transparent);
+  outline-offset: 5px;
+}
+
+.child-media-cover-grid__cover {
+  align-items: center;
+  aspect-ratio: 2 / 3;
+  background: color-mix(in srgb, currentColor 8%, transparent);
+  border-radius: 14px;
+  box-shadow: 0 10px 25px color-mix(in srgb, currentColor 12%, transparent);
+  display: flex;
+  justify-content: center;
+  overflow: hidden;
+  position: relative;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  width: 100%;
+}
+
+.child-media-cover-grid__cover img {
+  display: block;
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+
+.child-media-cover-grid__placeholder {
+  align-items: center;
+  background: linear-gradient(135deg, color-mix(in srgb, currentColor 18%, transparent), color-mix(in srgb, currentColor 4%, transparent));
+  display: flex;
+  font-size: clamp(2.5rem, 8vw, 4.5rem);
+  font-weight: 800;
+  height: 100%;
+  justify-content: center;
+  opacity: 0.55;
+  text-transform: uppercase;
+  width: 100%;
+}
+
+.child-media-cover-grid__content {
+  padding-block-start: 0.7rem;
+}
+
+.child-media-cover-grid__type {
+  color: color-mix(in srgb, currentColor 64%, transparent);
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  margin-block-end: 0.25rem;
+  text-transform: uppercase;
+}
+
+.child-media-cover-grid__title {
+  font-size: clamp(0.95rem, 0.9rem + 0.2vw, 1.08rem);
+  line-height: 1.25;
+  margin: 0;
+}
+
+.child-media-cover-grid__meta,
+.child-media-cover-grid__source,
+.child-media-cover-grid__empty {
+  color: color-mix(in srgb, currentColor 68%, transparent);
+  font-size: 0.86rem;
+  line-height: 1.35;
+  margin: 0.25rem 0 0;
+}
+
+.child-media-cover-grid__source {
+  font-size: 0.78rem;
+}
+
+@media (max-width: 600px) {
+  .child-media-cover-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -24,6 +24,10 @@ function child_get_dynamic_blocks(): array {
 			'block_name'  => 'child/media-recommendation',
 			'render_file' => 'blocks/media-recommendation/render.php',
 		],
+		'media-cover-grid'         => [
+			'block_name'  => 'child/media-cover-grid',
+			'render_file' => 'blocks/media-cover-grid/render.php',
+		],
 		'pixelfed-feed'            => [
 			'block_name'  => 'child/pixelfed-feed',
 			'render_file' => 'blocks/pixelfed-feed/render.php',

--- a/inc/media-cover-grid.php
+++ b/inc/media-cover-grid.php
@@ -5,7 +5,7 @@
  * @package TwentyTwentyFiveChild
  */
 
-const CHILD_MEDIA_COVER_GRID_CACHE_KEY = 'child_media_cover_grid_items_v1';
+const CHILD_MEDIA_COVER_GRID_CACHE_KEY = 'child_media_cover_grid_items_v2';
 
 /**
  * Get the translated display label for a media-grid item type.
@@ -176,10 +176,19 @@ function child_normalize_media_cover_grid_block( array $block, WP_Post $post ): 
 		return null;
 	}
 
-	$item['sourcePostId']        = (int) $post->ID;
-	$item['sourcePostTitle']     = get_the_title( $post );
-	$item['sourcePostUrl']       = get_permalink( $post );
-	$item['sourcePostTimestamp'] = (int) get_post_time( 'U', true, $post );
+	$source_post = [
+		'id'        => (int) $post->ID,
+		'title'     => get_the_title( $post ),
+		'url'       => get_permalink( $post ),
+		'timestamp' => (int) get_post_time( 'U', true, $post ),
+	];
+
+	$item['sourcePostId']        = $source_post['id'];
+	$item['sourcePostTitle']     = $source_post['title'];
+	$item['sourcePostUrl']       = $source_post['url'];
+	$item['sourcePostTimestamp'] = $source_post['timestamp'];
+	$item['sourcePosts']         = [ $source_post ];
+	$item['mentionCount']        = 1;
 	$item['dedupeKey']           = child_get_media_cover_grid_dedupe_key( $item );
 
 	return $item;
@@ -192,33 +201,41 @@ function child_normalize_media_cover_grid_block( array $block, WP_Post $post ): 
  * @return string
  */
 function child_get_media_cover_grid_dedupe_key( array $item ): string {
-	$type = (string) ( $item['type'] ?? '' );
+	$type  = (string) ( $item['type'] ?? '' );
+	$title = child_normalize_media_cover_grid_key_part( (string) ( $item['title'] ?? '' ) );
+	$meta  = child_normalize_media_cover_grid_key_part( (string) ( $item['meta'] ?? '' ) );
 
 	if ( ( 'movie' === $type || 'tv' === $type ) && ! empty( $item['tmdbId'] ) ) {
-		return $type . ':' . (int) $item['tmdbId'];
+		return $type . ':tmdb:' . (int) $item['tmdbId'];
 	}
 
 	if ( 'game' === $type && ! empty( $item['rawgId'] ) ) {
-		return 'game:' . (int) $item['rawgId'];
+		return 'game:rawg:' . (int) $item['rawgId'];
 	}
 
-	if ( 'book' === $type ) {
-		return implode(
-			':',
-			[
-				'book',
-				child_normalize_media_cover_grid_key_part( (string) ( $item['title'] ?? '' ) ),
-				child_normalize_media_cover_grid_key_part( (string) ( $item['meta'] ?? '' ) ),
-				child_normalize_media_cover_grid_key_part( (string) ( $item['externalUrl'] ?? '' ) ),
-			]
-		);
+	if ( 'book' === $type && '' !== $title ) {
+		$author = $meta;
+
+		if ( '' !== $author ) {
+			return 'book:title-author:' . $title . ':' . $author;
+		}
+	}
+
+	if ( '' !== $title ) {
+		$year = child_get_media_cover_grid_year_from_meta( $meta );
+
+		if ( '' !== $year ) {
+			return $type . ':title-year:' . $title . ':' . $year;
+		}
+
+		return $type . ':title:' . $title;
 	}
 
 	return implode(
 		':',
 		[
 			$type,
-			child_normalize_media_cover_grid_key_part( (string) ( $item['title'] ?? '' ) ),
+			child_normalize_media_cover_grid_key_part( (string) ( $item['externalUrl'] ?? '' ) ),
 			child_normalize_media_cover_grid_key_part( (string) ( $item['coverUrl'] ?? '' ) ),
 		]
 	);
@@ -237,6 +254,21 @@ function child_normalize_media_cover_grid_key_part( string $value ): string {
 	return null === $value ? '' : $value;
 }
 
+
+/**
+ * Extract a year from normalized metadata when available.
+ *
+ * @param string $meta Normalized metadata.
+ * @return string
+ */
+function child_get_media_cover_grid_year_from_meta( string $meta ): string {
+	if ( preg_match( '/\b(19|20)\d{2}\b/', $meta, $matches ) ) {
+		return $matches[0];
+	}
+
+	return '';
+}
+
 /**
  * Remove duplicates, keeping the newest source post per key.
  *
@@ -253,16 +285,125 @@ function child_dedupe_media_cover_grid_items( array $items ): array {
 
 		$key = (string) ( $item['dedupeKey'] ?? child_get_media_cover_grid_dedupe_key( $item ) );
 		if ( '' === $key ) {
-			$deduped[] = $item;
+			$deduped[] = child_add_media_cover_grid_mention_summary( $item );
 			continue;
 		}
 
-		if ( ! isset( $deduped[ $key ] ) || (int) ( $item['sourcePostTimestamp'] ?? 0 ) > (int) ( $deduped[ $key ]['sourcePostTimestamp'] ?? 0 ) ) {
-			$deduped[ $key ] = $item;
+		if ( ! isset( $deduped[ $key ] ) ) {
+			$deduped[ $key ] = child_add_media_cover_grid_mention_summary( $item );
+			continue;
 		}
+
+		$deduped[ $key ] = child_merge_media_cover_grid_duplicate_item( $deduped[ $key ], $item );
 	}
 
 	return array_values( $deduped );
+}
+
+/**
+ * Merge a duplicate media mention into the item kept for the grid.
+ *
+ * @param array<string, mixed> $kept      Existing deduplicated item.
+ * @param array<string, mixed> $duplicate Duplicate item.
+ * @return array<string, mixed>
+ */
+function child_merge_media_cover_grid_duplicate_item( array $kept, array $duplicate ): array {
+	$kept_sources      = child_get_media_cover_grid_source_posts( $kept );
+	$duplicate_sources = child_get_media_cover_grid_source_posts( $duplicate );
+	$sources           = [];
+
+	foreach ( array_merge( $kept_sources, $duplicate_sources ) as $source ) {
+		$source_id = (int) ( $source['id'] ?? 0 );
+		if ( $source_id <= 0 ) {
+			continue;
+		}
+
+		$sources[ $source_id ] = $source;
+	}
+
+	usort(
+		$sources,
+		static function( array $a, array $b ): int {
+			return (int) ( $b['timestamp'] ?? 0 ) <=> (int) ( $a['timestamp'] ?? 0 );
+		}
+	);
+
+	$newest_source = $sources[0] ?? null;
+
+	if ( $newest_source && (int) ( $newest_source['timestamp'] ?? 0 ) > (int) ( $kept['sourcePostTimestamp'] ?? 0 ) ) {
+		$duplicate['sourcePosts']  = $sources;
+		$duplicate['mentionCount'] = count( $sources );
+
+		return $duplicate;
+	}
+
+	$kept['sourcePosts']  = $sources;
+	$kept['mentionCount'] = count( $sources );
+
+	return $kept;
+}
+
+/**
+ * Ensure a media item has mention summary fields.
+ *
+ * @param array<string, mixed> $item Media item.
+ * @return array<string, mixed>
+ */
+function child_add_media_cover_grid_mention_summary( array $item ): array {
+	$sources              = child_get_media_cover_grid_source_posts( $item );
+	$item['sourcePosts']  = $sources;
+	$item['mentionCount'] = count( $sources );
+
+	return $item;
+}
+
+/**
+ * Return normalized source post summaries for a media item.
+ *
+ * @param array<string, mixed> $item Media item.
+ * @return array<int, array{id:int,title:string,url:string,timestamp:int}>
+ */
+function child_get_media_cover_grid_source_posts( array $item ): array {
+	if ( ! empty( $item['sourcePosts'] ) && is_array( $item['sourcePosts'] ) ) {
+		return array_values(
+			array_filter(
+				array_map(
+					static function( $source ): ?array {
+						if ( ! is_array( $source ) ) {
+							return null;
+						}
+
+						$source_id = (int) ( $source['id'] ?? 0 );
+						if ( $source_id <= 0 ) {
+							return null;
+						}
+
+						return [
+							'id'        => $source_id,
+							'title'     => (string) ( $source['title'] ?? '' ),
+							'url'       => esc_url_raw( (string) ( $source['url'] ?? '' ) ),
+							'timestamp' => (int) ( $source['timestamp'] ?? 0 ),
+						];
+					},
+					$item['sourcePosts']
+				)
+			)
+		);
+	}
+
+	$source_id = (int) ( $item['sourcePostId'] ?? 0 );
+	if ( $source_id <= 0 ) {
+		return [];
+	}
+
+	return [
+		[
+			'id'        => $source_id,
+			'title'     => (string) ( $item['sourcePostTitle'] ?? '' ),
+			'url'       => esc_url_raw( (string) ( $item['sourcePostUrl'] ?? '' ) ),
+			'timestamp' => (int) ( $item['sourcePostTimestamp'] ?? 0 ),
+		],
+	];
 }
 
 /**

--- a/inc/media-cover-grid.php
+++ b/inc/media-cover-grid.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ * Media Cover Grid helpers.
+ *
+ * @package TwentyTwentyFiveChild
+ */
+
+const CHILD_MEDIA_COVER_GRID_CACHE_KEY = 'child_media_cover_grid_items_v1';
+
+/**
+ * Get the translated display label for a media-grid item type.
+ *
+ * @param string $type Item type.
+ * @return string
+ */
+function child_get_media_cover_grid_type_label( string $type ): string {
+	$labels = [
+		'book'  => __( 'Buch', 'child' ),
+		'movie' => __( 'Film', 'child' ),
+		'tv'    => __( 'Serie', 'child' ),
+		'game'  => __( 'Videospiel', 'child' ),
+	];
+
+	return $labels[ $type ] ?? __( 'Medium', 'child' );
+}
+
+/**
+ * Build the media item cache from published posts.
+ *
+ * @param bool $allow_duplicates Whether duplicate media entries should be returned.
+ * @return array<int, array<string, mixed>>
+ */
+function child_get_media_cover_grid_items( bool $allow_duplicates = false ): array {
+	$items = get_transient( CHILD_MEDIA_COVER_GRID_CACHE_KEY );
+
+	if ( ! is_array( $items ) ) {
+		$items = child_build_media_cover_grid_items();
+		set_transient( CHILD_MEDIA_COVER_GRID_CACHE_KEY, $items, HOUR_IN_SECONDS * 12 );
+	}
+
+	if ( $allow_duplicates ) {
+		return $items;
+	}
+
+	return child_dedupe_media_cover_grid_items( $items );
+}
+
+/**
+ * Query posts and collect all supported media block attributes.
+ *
+ * @return array<int, array<string, mixed>>
+ */
+function child_build_media_cover_grid_items(): array {
+	$query = new WP_Query(
+		[
+			'post_type'              => 'post',
+			'post_status'            => 'publish',
+			'posts_per_page'         => -1,
+			'orderby'                => 'date',
+			'order'                  => 'DESC',
+			'fields'                 => 'all',
+			'no_found_rows'          => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+		]
+	);
+
+	$items = [];
+
+	foreach ( $query->posts as $post ) {
+		if ( ! $post instanceof WP_Post ) {
+			continue;
+		}
+
+		$blocks = parse_blocks( $post->post_content );
+		$items  = array_merge( $items, child_extract_media_items_from_blocks( $blocks, $post ) );
+	}
+
+	return $items;
+}
+
+/**
+ * Recursively extract media items from parsed Gutenberg blocks.
+ *
+ * @param array<int, array<string, mixed>> $blocks Parsed blocks.
+ * @param WP_Post                         $post   Source post.
+ * @return array<int, array<string, mixed>>
+ */
+function child_extract_media_items_from_blocks( array $blocks, WP_Post $post ): array {
+	$items = [];
+
+	foreach ( $blocks as $block ) {
+		if ( ! is_array( $block ) ) {
+			continue;
+		}
+
+		$item = child_normalize_media_cover_grid_block( $block, $post );
+		if ( null !== $item ) {
+			$items[] = $item;
+		}
+
+		if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+			$items = array_merge( $items, child_extract_media_items_from_blocks( $block['innerBlocks'], $post ) );
+		}
+	}
+
+	return $items;
+}
+
+/**
+ * Normalize one supported block into a shared media item shape.
+ *
+ * @param array<string, mixed> $block Parsed Gutenberg block.
+ * @param WP_Post             $post  Source post.
+ * @return array<string, mixed>|null
+ */
+function child_normalize_media_cover_grid_block( array $block, WP_Post $post ): ?array {
+	$block_name = (string) ( $block['blockName'] ?? '' );
+	$attrs      = is_array( $block['attrs'] ?? null ) ? $block['attrs'] : [];
+	$item       = null;
+
+	if ( 'child/book-rating' === $block_name ) {
+		$title = trim( (string) ( $attrs['bookTitle'] ?? '' ) );
+		if ( '' === $title ) {
+			return null;
+		}
+
+		$item = [
+			'type'        => 'book',
+			'title'       => $title,
+			'meta'        => trim( (string) ( $attrs['author'] ?? '' ) ),
+			'coverUrl'    => esc_url_raw( (string) ( $attrs['coverUrl'] ?? '' ) ),
+			'externalUrl' => esc_url_raw( (string) ( $attrs['shopUrl'] ?? '' ) ),
+		];
+	} elseif ( 'child/media-recommendation' === $block_name ) {
+		$title = trim( (string) ( $attrs['mediaTitle'] ?? '' ) );
+		if ( '' === $title ) {
+			return null;
+		}
+
+		$media_type = 'tv' === ( $attrs['mediaType'] ?? '' ) ? 'tv' : 'movie';
+		$item       = [
+			'type'        => $media_type,
+			'title'       => $title,
+			'meta'        => trim( (string) ( $attrs['releaseYear'] ?? '' ) ),
+			'coverUrl'    => esc_url_raw( (string) ( $attrs['posterUrl'] ?? '' ) ),
+			'externalUrl' => esc_url_raw( (string) ( $attrs['serviceUrl'] ?? '' ) ),
+			'tmdbId'      => absint( $attrs['tmdbId'] ?? 0 ),
+		];
+	} elseif ( 'child/videogame-recommendation' === $block_name ) {
+		$title = trim( (string) ( $attrs['gameTitle'] ?? '' ) );
+		if ( '' === $title ) {
+			return null;
+		}
+
+		$platforms = is_array( $attrs['platforms'] ?? null ) ? array_filter( array_map( 'strval', $attrs['platforms'] ) ) : [];
+		$year      = trim( (string) ( $attrs['releaseYear'] ?? '' ) );
+		if ( '' === $year && ! empty( $attrs['releaseDate'] ) ) {
+			$timestamp = strtotime( (string) $attrs['releaseDate'] );
+			$year      = $timestamp ? date_i18n( 'Y', $timestamp ) : '';
+		}
+
+		$meta_parts = array_filter( [ $year, implode( ', ', array_slice( $platforms, 0, 3 ) ) ] );
+
+		$item = [
+			'type'        => 'game',
+			'title'       => $title,
+			'meta'        => implode( ' · ', $meta_parts ),
+			'coverUrl'    => esc_url_raw( (string) ( $attrs['coverUrl'] ?? '' ) ),
+			'externalUrl' => esc_url_raw( (string) ( $attrs['shopUrl'] ?? '' ) ),
+			'rawgId'      => absint( $attrs['rawgId'] ?? 0 ),
+		];
+	}
+
+	if ( null === $item ) {
+		return null;
+	}
+
+	$item['sourcePostId']        = (int) $post->ID;
+	$item['sourcePostTitle']     = get_the_title( $post );
+	$item['sourcePostUrl']       = get_permalink( $post );
+	$item['sourcePostTimestamp'] = (int) get_post_time( 'U', true, $post );
+	$item['dedupeKey']           = child_get_media_cover_grid_dedupe_key( $item );
+
+	return $item;
+}
+
+/**
+ * Compute a stable de-duplication key for a media item.
+ *
+ * @param array<string, mixed> $item Normalized media item.
+ * @return string
+ */
+function child_get_media_cover_grid_dedupe_key( array $item ): string {
+	$type = (string) ( $item['type'] ?? '' );
+
+	if ( ( 'movie' === $type || 'tv' === $type ) && ! empty( $item['tmdbId'] ) ) {
+		return $type . ':' . (int) $item['tmdbId'];
+	}
+
+	if ( 'game' === $type && ! empty( $item['rawgId'] ) ) {
+		return 'game:' . (int) $item['rawgId'];
+	}
+
+	if ( 'book' === $type ) {
+		return implode(
+			':',
+			[
+				'book',
+				child_normalize_media_cover_grid_key_part( (string) ( $item['title'] ?? '' ) ),
+				child_normalize_media_cover_grid_key_part( (string) ( $item['meta'] ?? '' ) ),
+				child_normalize_media_cover_grid_key_part( (string) ( $item['externalUrl'] ?? '' ) ),
+			]
+		);
+	}
+
+	return implode(
+		':',
+		[
+			$type,
+			child_normalize_media_cover_grid_key_part( (string) ( $item['title'] ?? '' ) ),
+			child_normalize_media_cover_grid_key_part( (string) ( $item['coverUrl'] ?? '' ) ),
+		]
+	);
+}
+
+/**
+ * Normalize one string segment for stable keys.
+ *
+ * @param string $value Raw value.
+ * @return string
+ */
+function child_normalize_media_cover_grid_key_part( string $value ): string {
+	$value = strtolower( remove_accents( trim( $value ) ) );
+	$value = preg_replace( '/\s+/', ' ', $value );
+
+	return null === $value ? '' : $value;
+}
+
+/**
+ * Remove duplicates, keeping the newest source post per key.
+ *
+ * @param array<int, array<string, mixed>> $items Media items.
+ * @return array<int, array<string, mixed>>
+ */
+function child_dedupe_media_cover_grid_items( array $items ): array {
+	$deduped = [];
+
+	foreach ( $items as $item ) {
+		if ( ! is_array( $item ) ) {
+			continue;
+		}
+
+		$key = (string) ( $item['dedupeKey'] ?? child_get_media_cover_grid_dedupe_key( $item ) );
+		if ( '' === $key ) {
+			$deduped[] = $item;
+			continue;
+		}
+
+		if ( ! isset( $deduped[ $key ] ) || (int) ( $item['sourcePostTimestamp'] ?? 0 ) > (int) ( $deduped[ $key ]['sourcePostTimestamp'] ?? 0 ) ) {
+			$deduped[ $key ] = $item;
+		}
+	}
+
+	return array_values( $deduped );
+}
+
+/**
+ * Flush the cached media-grid item list.
+ */
+function child_flush_media_cover_grid_cache(): void {
+	delete_transient( CHILD_MEDIA_COVER_GRID_CACHE_KEY );
+}
+
+/**
+ * Flush media-grid cache when post content changes.
+ *
+ * @param int $post_id Post ID.
+ */
+function child_flush_media_cover_grid_cache_for_post( int $post_id ): void {
+	if ( 'post' !== get_post_type( $post_id ) ) {
+		return;
+	}
+
+	child_flush_media_cover_grid_cache();
+}
+add_action( 'save_post', 'child_flush_media_cover_grid_cache_for_post' );
+add_action( 'deleted_post', 'child_flush_media_cover_grid_cache_for_post' );
+
+/**
+ * Flush media-grid cache when a post moves between statuses.
+ *
+ * @param string  $new_status New post status.
+ * @param string  $old_status Old post status.
+ * @param WP_Post $post       Post object.
+ */
+function child_flush_media_cover_grid_cache_for_status_transition( string $new_status, string $old_status, WP_Post $post ): void {
+	if ( 'post' !== $post->post_type || $new_status === $old_status ) {
+		return;
+	}
+
+	child_flush_media_cover_grid_cache();
+}
+add_action( 'transition_post_status', 'child_flush_media_cover_grid_cache_for_status_transition', 10, 3 );


### PR DESCRIPTION
### Motivation
- Provide a reusable grid block that automatically aggregates and displays cover art from existing media-related blocks in published posts.
- Improve theme feature set by offering a configurable, server-rendered block with deduplication and caching to avoid expensive queries on each request.
- Keep editor UX consistent with other blocks and expose options for filtering, sorting and presentation.

### Description
- Introduces a new block `child/media-cover-grid` with manifest (`blocks/media-cover-grid/block.json`), editor (`blocks/media-cover-grid/index.js`), editor styles (`editor.css`) and frontend styles (`style.css`).
- Adds a server render file (`blocks/media-cover-grid/render.php`) that queries a consolidated media item list, applies filtering, sorting, linking and outputs accessible markup.
- Implements helper functions in `inc/media-cover-grid.php` to build the media item cache from published posts (`child_build_media_cover_grid_items`), normalize supported blocks (`child_normalize_media_cover_grid_block`), compute dedupe keys, deduplicate items and flush the transient cache on post changes.
- Registers the dynamic block in shared registration arrays by updating `blocks/index.js` and `inc/blocks.php` so the block is discovered and rendered by the theme.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ec1a241ec83258238ef5ae2d76158)