### PR TITLE
Add Dynamic Block Feature Structure to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ Each block:
 - uses a server-side render callback from `blocks/<slug>/render.php` (where applicable)
 - receives block style enqueueing plus a global style fallback for compatibility
 
+
+### Dynamic Block Feature Structure
+
+When adding or changing a dynamic block, mirror the existing examples in `blocks/post-likes`, `blocks/media-cover-grid`, and `blocks/media-recommendation`:
+
+- Put block-owned assets under `blocks/{slug}/`. A feature should include `block.json` and `index.js`, then add `render.php` for dynamic output, `style.css` for front-end styles, `editor.css` for editor-only styles, and `view.js` only when the front end needs interactive behavior.
+- Put server-side helper modules in `inc/{slug}.php`. Keep `blocks/{slug}/render.php` focused on rendering sanitized markup and delegate reusable queries, REST/AJAX handlers, settings, cache helpers, and data normalization to the matching `inc/` file.
+- Expose render-time behavior through stable, public `child_*` functions instead of anonymous helper logic that other blocks cannot reuse. For example, `blocks/media-cover-grid/render.php` calls the public helpers from `inc/media-cover-grid.php`, while `blocks/post-likes/render.php` reads counts through the post-likes helper API.
+- Localize editor data from `inc/blocks.php` with `child_localize_block_editor_script( $block_name, $object_name, $data )` on `enqueue_block_editor_assets`, as `inc/media-recommendation.php` does for the Media Recommendation editor AJAX URL and nonce.
+- Name cache keys with a `child_{slug}_{purpose}_v{n}` convention, define them as constants in the owning `inc/{slug}.php`, and bump the version when the cached shape changes. Invalidate through explicit `child_flush_{slug}_cache()` helpers on all relevant write hooks, following `inc/media-cover-grid.php`; modules with write paths such as `inc/post-likes.php` should clear any future cached counts or aggregates immediately after inserts/deletes so REST responses and render callbacks stay consistent.
+
 ## API-Backed Features
 
 ### Media Recommendation (TMDB)


### PR DESCRIPTION
### Motivation

- Provide a concise, consistent guide for adding and maintaining dynamic blocks so new blocks follow the same file layout and runtime conventions. 
- Capture established patterns used by existing examples like `blocks/post-likes`, `blocks/media-cover-grid`, and `blocks/media-recommendation` so future work is interoperable and cache-safe.

### Description

- Inserted a new `### Dynamic Block Feature Structure` section in `README.md` describing expected files under `blocks/{slug}/` such as `block.json`, `index.js`, optional `view.js`, `render.php`, `style.css`, and `editor.css`.
- Documented that server-side helper modules should live in `inc/{slug}.php` and that `blocks/{slug}/render.php` should delegate reusable logic to those `inc/` helpers.
- Clarified that render callbacks should expose stable public `child_*` functions/APIs and that editor data should be localized via `child_localize_block_editor_script` from `inc/blocks.php` during `enqueue_block_editor_assets` as in `inc/media-recommendation.php`.
- Added cache key naming and invalidation conventions recommending `child_{slug}_{purpose}_v{n}` constants in `inc/{slug}.php` and explicit `child_flush_{slug}_cache()` invalidation hooks following `inc/media-cover-grid.php` and immediate clears for write-path modules like `inc/post-likes.php`.

### Testing

- Ran `git diff --check` to validate the working tree, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a208fdbe47483259369d3a2b85beed4)