### PR TITLE
Add music recommendation block and integrate music into Media Cover Grid

### DIFF
--- a/blocks/index.js
+++ b/blocks/index.js
@@ -4,6 +4,7 @@ import './book-rating';
 import './magic-cards';
 import './media-recommendation'; // Ensure consistency with other blocks by registering here
 import './media-cover-grid';
+import './music-recommendation';
 import './videogame-recommendation';
 import './pixelfed-feed';
 

--- a/blocks/media-cover-grid/block.json
+++ b/blocks/media-cover-grid/block.json
@@ -4,7 +4,7 @@
   "title": "Medien-Cover-Grid",
   "category": "widgets",
   "icon": "screenoptions",
-  "description": "Zeigt automatisch Cover aus Buch-, Film/Serien- und Videospiel-Blöcken in veröffentlichten Beiträgen.",
+  "description": "Zeigt automatisch Cover aus Buch-, Film/Serien-, Videospiel- und Musik-Blöcken in veröffentlichten Beiträgen.",
   "supports": {
     "html": false,
     "align": ["wide", "full"]
@@ -12,7 +12,7 @@
   "attributes": {
     "mediaTypes": {
       "type": "array",
-      "default": ["book", "movie", "tv", "game"]
+      "default": ["book", "movie", "tv", "game", "music"]
     },
     "maxItems": {
       "type": "number",

--- a/blocks/media-cover-grid/index.js
+++ b/blocks/media-cover-grid/index.js
@@ -16,7 +16,8 @@ const MEDIA_TYPE_OPTIONS = [
     { value: 'book', label: __('Bücher', 'child') },
     { value: 'movie', label: __('Filme', 'child') },
     { value: 'tv', label: __('Serien', 'child') },
-    { value: 'game', label: __('Videospiele', 'child') }
+    { value: 'game', label: __('Videospiele', 'child') },
+    { value: 'music', label: __('Musik', 'child') }
 ];
 
 const PREVIEW_ITEMS = [
@@ -43,6 +44,12 @@ const PREVIEW_ITEMS = [
         typeLabel: __('Videospiel', 'child'),
         title: __('Beispielspiel', 'child'),
         meta: __('PC, Switch', 'child')
+    },
+    {
+        type: 'music',
+        typeLabel: __('Musik', 'child'),
+        title: __('Beispielsong', 'child'),
+        meta: __('Künstler:in', 'child')
     }
 ];
 

--- a/blocks/media-cover-grid/render.php
+++ b/blocks/media-cover-grid/render.php
@@ -10,7 +10,7 @@ return function( array $attributes ): string {
 		return '';
 	}
 
-	$default_types     = [ 'book', 'movie', 'tv', 'game' ];
+	$default_types     = [ 'book', 'movie', 'tv', 'game', 'music' ];
 	$media_types       = $attributes['mediaTypes'] ?? $default_types;
 	$allowed_types     = array_values( array_intersect( $default_types, is_array( $media_types ) ? $media_types : $default_types ) );
 	$max_items         = max( 1, min( 120, absint( $attributes['maxItems'] ?? 48 ) ) );

--- a/blocks/music-recommendation/block.json
+++ b/blocks/music-recommendation/block.json
@@ -1,0 +1,58 @@
+{
+  "apiVersion": 3,
+  "name": "child/music-recommendation",
+  "title": "Musik",
+  "category": "widgets",
+  "icon": "format-audio",
+  "description": "Ein Block zur Anzeige von Alben und Songs mit legaler Hörprobe.",
+  "supports": {
+    "html": false
+  },
+  "attributes": {
+    "musicType": {
+      "type": "string",
+      "default": "song"
+    },
+    "title": {
+      "type": "string",
+      "default": ""
+    },
+    "artist": {
+      "type": "string",
+      "default": ""
+    },
+    "albumTitle": {
+      "type": "string",
+      "default": ""
+    },
+    "releaseYear": {
+      "type": "string",
+      "default": ""
+    },
+    "coverUrl": {
+      "type": "string",
+      "default": ""
+    },
+    "provider": {
+      "type": "string",
+      "default": "Apple/iTunes"
+    },
+    "providerId": {
+      "type": "string",
+      "default": ""
+    },
+    "providerUrl": {
+      "type": "string",
+      "default": ""
+    },
+    "previewUrl": {
+      "type": "string",
+      "default": ""
+    }
+  },
+  "textdomain": "twentyfivetwentyfivechild",
+  "editorScript": "file:./index.js",
+  "viewScript": "file:./view.js",
+  "editorStyle": "file:./editor.css",
+  "style": "file:./style.css"
+}

--- a/blocks/music-recommendation/editor.css
+++ b/blocks/music-recommendation/editor.css
@@ -50,3 +50,44 @@
 .music-preview--empty {
     opacity: 0.75;
 }
+
+/* Keep provider artwork usable inside the block editor, even when theme/editor image rules are broad. */
+.wp-block-child-music-recommendation .music-search-results {
+    max-width: 100%;
+}
+
+.wp-block-child-music-recommendation .components-button.music-search-result {
+    display: grid !important;
+    grid-template-columns: 56px minmax(0, 1fr);
+    align-items: center;
+    width: 100%;
+    max-width: 100%;
+    min-height: 72px;
+    overflow: hidden;
+    white-space: normal;
+}
+
+.wp-block-child-music-recommendation .music-search-result__thumb,
+.wp-block-child-music-recommendation .music-search-result__thumb img {
+    width: 56px !important;
+    height: 56px !important;
+    max-width: 56px !important;
+    max-height: 56px !important;
+}
+
+.wp-block-child-music-recommendation .music-search-result__thumb {
+    min-width: 56px;
+    border-radius: 4px;
+}
+
+.wp-block-child-music-recommendation .music-search-result__details {
+    min-width: 0;
+    overflow: hidden;
+}
+
+.wp-block-child-music-recommendation .music-search-result__title,
+.wp-block-child-music-recommendation .music-search-result__artist,
+.wp-block-child-music-recommendation .music-search-result__year {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/blocks/music-recommendation/editor.css
+++ b/blocks/music-recommendation/editor.css
@@ -1,0 +1,52 @@
+.music-search-panel {
+    margin-block-end: 1rem;
+}
+
+.music-search-button {
+    margin-block-end: 0.75rem;
+}
+
+.music-search-results {
+    display: grid;
+    gap: 0.5rem;
+    margin-block: 0.75rem 1rem;
+}
+
+.music-search-result {
+    justify-content: flex-start;
+    height: auto;
+    gap: 0.75rem;
+    padding: 0.5rem;
+    text-align: left;
+}
+
+.music-search-result__thumb {
+    display: inline-grid;
+    flex: 0 0 56px;
+    width: 56px;
+    height: 56px;
+    place-items: center;
+    overflow: hidden;
+    background: rgba(0, 0, 0, 0.08);
+}
+
+.music-search-result__thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.music-search-result__details {
+    display: grid;
+    gap: 0.15rem;
+}
+
+.music-search-result__title {
+    font-weight: 700;
+}
+
+.music-search-result__artist,
+.music-search-result__year,
+.music-preview--empty {
+    opacity: 0.75;
+}

--- a/blocks/music-recommendation/index.js
+++ b/blocks/music-recommendation/index.js
@@ -35,16 +35,6 @@ const MusicPreview = ({ attributes }) => {
                     <p className="child-music-card__album">{albumTitle}</p>
                 ) : null}
                 {releaseYear ? <p className="child-music-card__year">{releaseYear}</p> : null}
-                {previewUrl ? (
-                    <p className="child-music-card__privacy-note">
-                        {__('Die Hörprobe wird erst nach einem Klick geladen. Dabei kann eine Verbindung zum Anbieter hergestellt werden.', 'child')}
-                    </p>
-                ) : null}
-                {providerUrl ? (
-                    <a className="child-music-card__provider-link" href={providerUrl} target="_blank" rel="noopener noreferrer">
-                        {__('Bei Anbieter öffnen', 'child')} ({provider || 'Apple/iTunes'})
-                    </a>
-                ) : null}
             </div>
         </div>
     );

--- a/blocks/music-recommendation/index.js
+++ b/blocks/music-recommendation/index.js
@@ -1,0 +1,212 @@
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, SelectControl, TextControl, Button, Spinner, Notice } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import metadata from './block.json';
+import './editor.css';
+import './style.css';
+
+const MusicPreview = ({ attributes }) => {
+    const { musicType, title, artist, albumTitle, releaseYear, coverUrl, provider, providerUrl, previewUrl } = attributes;
+
+    if (!title?.trim()) {
+        return <div className="music-preview--empty">{__('Suche einen Song oder ein Album aus.', 'child')}</div>;
+    }
+
+    const typeLabel = musicType === 'album' ? __('Album', 'child') : __('Song', 'child');
+
+    return (
+        <div className="child-music-card" aria-label={typeLabel}>
+            <div className="child-music-card__media">
+                {coverUrl ? (
+                    <img className="child-music-card__cover" src={coverUrl} alt={title} loading="lazy" />
+                ) : (
+                    <div className="child-music-card__placeholder" aria-hidden="true">♪</div>
+                )}
+            </div>
+            <div className="child-music-card__meta">
+                <span className="child-music-card__type">{typeLabel}</span>
+                <h3 className="child-music-card__title">{title}</h3>
+                {artist ? <p className="child-music-card__artist">{artist}</p> : null}
+                {musicType === 'song' && albumTitle && albumTitle !== title ? (
+                    <p className="child-music-card__album">{albumTitle}</p>
+                ) : null}
+                {releaseYear ? <p className="child-music-card__year">{releaseYear}</p> : null}
+                {previewUrl ? (
+                    <p className="child-music-card__privacy-note">
+                        {__('Die Hörprobe wird erst nach einem Klick geladen. Dabei kann eine Verbindung zum Anbieter hergestellt werden.', 'child')}
+                    </p>
+                ) : null}
+                {providerUrl ? (
+                    <a className="child-music-card__provider-link" href={providerUrl} target="_blank" rel="noopener noreferrer">
+                        {__('Bei Anbieter öffnen', 'child')} ({provider || 'Apple/iTunes'})
+                    </a>
+                ) : null}
+            </div>
+        </div>
+    );
+};
+
+const SearchResults = ({ results, onSelect, selectedId }) => {
+    if (!results.length) {
+        return null;
+    }
+
+    return (
+        <div className="music-search-results">
+            {results.map((item) => (
+                <Button
+                    key={`${item.musicType}-${item.id}`}
+                    variant={item.id === selectedId ? 'primary' : 'secondary'}
+                    onClick={() => onSelect(item)}
+                    className={`music-search-result${item.id === selectedId ? ' is-active' : ''}`}
+                >
+                    {item.coverUrl ? (
+                        <span className="music-search-result__thumb"><img src={item.coverUrl} alt="" loading="lazy" /></span>
+                    ) : (
+                        <span className="music-search-result__thumb music-search-result__thumb--placeholder" aria-hidden="true">♪</span>
+                    )}
+                    <span className="music-search-result__details">
+                        <span className="music-search-result__title">{item.title}</span>
+                        {item.artist ? <span className="music-search-result__artist">{item.artist}</span> : null}
+                        {item.releaseYear ? <span className="music-search-result__year">{item.releaseYear}</span> : null}
+                    </span>
+                </Button>
+            ))}
+        </div>
+    );
+};
+
+registerBlockType(metadata.name, {
+    ...metadata,
+    edit: ({ attributes, setAttributes }) => {
+        const blockProps = useBlockProps();
+        const { musicType, title, artist, albumTitle, releaseYear, coverUrl, providerUrl, previewUrl } = attributes;
+        const [searchTerm, setSearchTerm] = useState(title || '');
+        const [results, setResults] = useState([]);
+        const [isSearching, setIsSearching] = useState(false);
+        const [error, setError] = useState('');
+        const [selectedId, setSelectedId] = useState(attributes.providerId || '');
+
+        useEffect(() => {
+            if (!searchTerm && title) {
+                setSearchTerm(title);
+            }
+        }, [title]);
+
+        const searchMusic = async () => {
+            if (!searchTerm.trim()) {
+                setError(__('Bitte gib einen Suchbegriff ein.', 'child'));
+                return;
+            }
+
+            setIsSearching(true);
+            setError('');
+
+            try {
+                const response = await apiFetch({
+                    path: addQueryArgs('/child/v1/music', {
+                        q: searchTerm,
+                        musicType,
+                    }),
+                });
+                const found = response?.results || [];
+                setResults(found);
+                if (!found.length) {
+                    setError(__('Keine Musik gefunden.', 'child'));
+                }
+            } catch (fetchError) {
+                setError(fetchError?.message || __('Die Musiksuche konnte nicht geladen werden.', 'child'));
+            } finally {
+                setIsSearching(false);
+            }
+        };
+
+        const selectMusic = (item) => {
+            setSelectedId(item.id);
+            setSearchTerm(item.title);
+            setAttributes({
+                musicType: item.musicType || musicType,
+                title: item.title || title,
+                artist: item.artist || artist,
+                albumTitle: item.albumTitle || albumTitle,
+                releaseYear: item.releaseYear || releaseYear,
+                coverUrl: item.coverUrl || coverUrl,
+                provider: item.provider || 'Apple/iTunes',
+                providerId: item.id || '',
+                providerUrl: item.providerUrl || providerUrl,
+                previewUrl: item.previewUrl || '',
+            });
+        };
+
+        return (
+            <div {...blockProps}>
+                <InspectorControls>
+                    <PanelBody title={__('Musik-Einstellungen', 'child')} initialOpen>
+                        <SelectControl
+                            label={__('Typ', 'child')}
+                            value={musicType}
+                            options={[
+                                { label: __('Song', 'child'), value: 'song' },
+                                { label: __('Album', 'child'), value: 'album' },
+                            ]}
+                            onChange={(value) => {
+                                setAttributes({ musicType: value, previewUrl: value === 'album' ? '' : previewUrl });
+                                setResults([]);
+                            }}
+                        />
+                        <TextControl label={__('Titel', 'child')} value={title} onChange={(value) => setAttributes({ title: value })} />
+                        <TextControl label={__('Künstler:in', 'child')} value={artist} onChange={(value) => setAttributes({ artist: value })} />
+                        <TextControl label={__('Album', 'child')} value={albumTitle} onChange={(value) => setAttributes({ albumTitle: value })} />
+                        <TextControl label={__('Jahr', 'child')} value={releaseYear} onChange={(value) => setAttributes({ releaseYear: value })} />
+                        <TextControl label={__('Cover-URL', 'child')} value={coverUrl} onChange={(value) => setAttributes({ coverUrl: value })} />
+                        <TextControl label={__('Anbieter-Link', 'child')} value={providerUrl} onChange={(value) => setAttributes({ providerUrl: value })} />
+                        <TextControl label={__('Hörprobe-URL', 'child')} value={previewUrl} onChange={(value) => setAttributes({ previewUrl: value })} help={__('Nur rechtmäßig bereitgestellte Preview-URLs verwenden; keine vollständigen Songs ohne Lizenz einbinden.', 'child')} />
+                    </PanelBody>
+                    <PanelBody title={__('Recht & Datenschutz', 'child')} initialOpen={false}>
+                        <Notice status="info" isDismissible={false}>
+                            {__('Der Block nutzt Anbieter-Metadaten als Empfehlung/Promotion. Hörproben werden im Frontend erst nach Klick geladen, damit keine externe Audio-Verbindung ohne Aktion der Leser:innen aufgebaut wird.', 'child')}
+                        </Notice>
+                    </PanelBody>
+                </InspectorControls>
+
+                <div className="music-search-panel">
+                    <SelectControl
+                        label={__('Was möchtest du empfehlen?', 'child')}
+                        value={musicType}
+                        options={[
+                            { label: __('Song', 'child'), value: 'song' },
+                            { label: __('Album', 'child'), value: 'album' },
+                        ]}
+                        onChange={(value) => {
+                            setAttributes({ musicType: value, previewUrl: value === 'album' ? '' : previewUrl });
+                            setResults([]);
+                        }}
+                    />
+                    <TextControl
+                        label={__('Musik suchen', 'child')}
+                        value={searchTerm}
+                        onChange={setSearchTerm}
+                        onKeyDown={(event) => {
+                            if (event.key === 'Enter') {
+                                event.preventDefault();
+                                searchMusic();
+                            }
+                        }}
+                    />
+                    <Button variant="primary" onClick={searchMusic} disabled={isSearching} className="music-search-button">
+                        {isSearching ? __('Suche…', 'child') : __('Suchen', 'child')}
+                    </Button>
+                    {isSearching ? <Spinner /> : null}
+                    {error ? <Notice status="warning" isDismissible={false}>{error}</Notice> : null}
+                    <SearchResults results={results} onSelect={selectMusic} selectedId={selectedId} />
+                </div>
+
+                <MusicPreview attributes={attributes} />
+            </div>
+        );
+    },
+});

--- a/blocks/music-recommendation/render.php
+++ b/blocks/music-recommendation/render.php
@@ -17,8 +17,6 @@ return function( array $attributes ): string {
 	$album_title  = trim( (string) ( $attributes['albumTitle'] ?? '' ) );
 	$release_year = trim( (string) ( $attributes['releaseYear'] ?? '' ) );
 	$cover_url    = esc_url( (string) ( $attributes['coverUrl'] ?? '' ) );
-	$provider     = trim( (string) ( $attributes['provider'] ?? 'Apple/iTunes' ) );
-	$provider_url = esc_url( (string) ( $attributes['providerUrl'] ?? '' ) );
 	$preview_url  = 'song' === $music_type ? esc_url( (string) ( $attributes['previewUrl'] ?? '' ) ) : '';
 
 	ob_start();
@@ -30,6 +28,20 @@ return function( array $attributes ): string {
 					<img src="<?php echo $cover_url; ?>" alt="<?php echo esc_attr( $title ); ?>" class="child-music-card__cover" loading="lazy" />
 				<?php else : ?>
 					<div class="child-music-card__placeholder" aria-hidden="true">♪</div>
+				<?php endif; ?>
+
+				<?php if ( $preview_url ) : ?>
+					<button
+						type="button"
+						class="child-music-card__preview-button"
+						data-preview-url="<?php echo esc_url( $preview_url ); ?>"
+						data-play-label="<?php echo esc_attr__( 'Hörprobe abspielen', 'child' ); ?>"
+						data-pause-label="<?php echo esc_attr__( 'Hörprobe pausieren', 'child' ); ?>"
+						aria-label="<?php echo esc_attr__( 'Hörprobe abspielen', 'child' ); ?>"
+						aria-pressed="false"
+					>
+						<span class="child-music-card__preview-icon" aria-hidden="true">▶</span>
+					</button>
 				<?php endif; ?>
 			</div>
 
@@ -46,28 +58,6 @@ return function( array $attributes ): string {
 					<p class="child-music-card__year"><?php echo esc_html( $release_year ); ?></p>
 				<?php endif; ?>
 
-				<?php if ( $preview_url ) : ?>
-					<p class="child-music-card__privacy-note">
-						<?php esc_html_e( 'Die Hörprobe wird erst nach deinem Klick geladen. Dabei kann eine Verbindung zum Anbieter hergestellt werden.', 'child' ); ?>
-					</p>
-					<div class="child-music-card__preview" data-preview-url="<?php echo esc_url( $preview_url ); ?>">
-						<button type="button" class="child-music-card__preview-button">
-							<?php esc_html_e( 'Hörprobe laden', 'child' ); ?>
-						</button>
-					</div>
-				<?php endif; ?>
-
-				<?php if ( $provider_url ) : ?>
-					<a class="child-music-card__provider-link" href="<?php echo $provider_url; ?>" target="_blank" rel="noopener noreferrer">
-						<?php
-						printf(
-							/* translators: %s: provider name. */
-							esc_html__( 'Bei %s öffnen', 'child' ),
-							esc_html( $provider ?: 'Apple/iTunes' )
-						);
-						?>
-					</a>
-				<?php endif; ?>
 			</div>
 		</div>
 	</div>

--- a/blocks/music-recommendation/render.php
+++ b/blocks/music-recommendation/render.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Render Music Recommendation Block.
+ *
+ * @package TwentyTwentyFiveChild
+ */
+
+return function( array $attributes ): string {
+	$title = trim( (string) ( $attributes['title'] ?? '' ) );
+	if ( '' === $title ) {
+		return '';
+	}
+
+	$music_type   = 'album' === ( $attributes['musicType'] ?? '' ) ? 'album' : 'song';
+	$type_label   = 'album' === $music_type ? __( 'Album', 'child' ) : __( 'Song', 'child' );
+	$artist       = trim( (string) ( $attributes['artist'] ?? '' ) );
+	$album_title  = trim( (string) ( $attributes['albumTitle'] ?? '' ) );
+	$release_year = trim( (string) ( $attributes['releaseYear'] ?? '' ) );
+	$cover_url    = esc_url( (string) ( $attributes['coverUrl'] ?? '' ) );
+	$provider     = trim( (string) ( $attributes['provider'] ?? 'Apple/iTunes' ) );
+	$provider_url = esc_url( (string) ( $attributes['providerUrl'] ?? '' ) );
+	$preview_url  = 'song' === $music_type ? esc_url( (string) ( $attributes['previewUrl'] ?? '' ) ) : '';
+
+	ob_start();
+	?>
+	<div <?php echo get_block_wrapper_attributes(); ?>>
+		<div class="child-music-card child-music-card--<?php echo esc_attr( $music_type ); ?>" aria-label="<?php echo esc_attr( $type_label ); ?>">
+			<div class="child-music-card__media">
+				<?php if ( $cover_url ) : ?>
+					<img src="<?php echo $cover_url; ?>" alt="<?php echo esc_attr( $title ); ?>" class="child-music-card__cover" loading="lazy" />
+				<?php else : ?>
+					<div class="child-music-card__placeholder" aria-hidden="true">♪</div>
+				<?php endif; ?>
+			</div>
+
+			<div class="child-music-card__meta">
+				<span class="child-music-card__type"><?php echo esc_html( $type_label ); ?></span>
+				<h3 class="child-music-card__title"><?php echo esc_html( $title ); ?></h3>
+				<?php if ( $artist ) : ?>
+					<p class="child-music-card__artist"><?php echo esc_html( $artist ); ?></p>
+				<?php endif; ?>
+				<?php if ( 'song' === $music_type && $album_title && $album_title !== $title ) : ?>
+					<p class="child-music-card__album"><?php echo esc_html( $album_title ); ?></p>
+				<?php endif; ?>
+				<?php if ( $release_year ) : ?>
+					<p class="child-music-card__year"><?php echo esc_html( $release_year ); ?></p>
+				<?php endif; ?>
+
+				<?php if ( $preview_url ) : ?>
+					<p class="child-music-card__privacy-note">
+						<?php esc_html_e( 'Die Hörprobe wird erst nach deinem Klick geladen. Dabei kann eine Verbindung zum Anbieter hergestellt werden.', 'child' ); ?>
+					</p>
+					<div class="child-music-card__preview" data-preview-url="<?php echo esc_url( $preview_url ); ?>">
+						<button type="button" class="child-music-card__preview-button">
+							<?php esc_html_e( 'Hörprobe laden', 'child' ); ?>
+						</button>
+					</div>
+				<?php endif; ?>
+
+				<?php if ( $provider_url ) : ?>
+					<a class="child-music-card__provider-link" href="<?php echo $provider_url; ?>" target="_blank" rel="noopener noreferrer">
+						<?php
+						printf(
+							/* translators: %s: provider name. */
+							esc_html__( 'Bei %s öffnen', 'child' ),
+							esc_html( $provider ?: 'Apple/iTunes' )
+						);
+						?>
+					</a>
+				<?php endif; ?>
+			</div>
+		</div>
+	</div>
+	<?php
+	return ob_get_clean();
+};

--- a/blocks/music-recommendation/style.css
+++ b/blocks/music-recommendation/style.css
@@ -1,61 +1,96 @@
 .wp-block-child-music-recommendation {
-    margin: 1.5rem 0;
+    margin: clamp(1.5rem, 4vw, 3rem) 0;
 }
 
 .child-music-card {
-    display: grid;
-    grid-template-columns: minmax(120px, 180px) 1fr;
-    gap: 1.25rem;
-    align-items: start;
-    padding: 1rem;
-    border: 1px solid currentColor;
-    border-radius: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
 }
 
 .child-music-card__media {
-    aspect-ratio: 1;
-    background: rgba(0, 0, 0, 0.08);
-    border-radius: 0.5rem;
-    overflow: hidden;
+    position: relative;
+    width: min(100%, clamp(160px, 65vw, 280px));
+    max-width: 100%;
+    border-radius: 12px;
+    background: #fff;
+    display: flex;
+    justify-content: center;
 }
 
 .child-music-card__cover {
-    display: block;
     width: 100%;
-    height: 100%;
+    max-width: 100%;
+    height: auto;
+    aspect-ratio: 1;
     object-fit: cover;
+    border-radius: 10px;
+    display: block;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15),
+                0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 .child-music-card__placeholder {
+    width: 100%;
+    aspect-ratio: 1;
+    border-radius: 10px;
+    background: repeating-linear-gradient(
+        135deg,
+        rgba(220, 211, 196, 0.55),
+        rgba(220, 211, 196, 0.55) 12px,
+        rgba(255, 255, 255, 0.55) 12px,
+        rgba(255, 255, 255, 0.55) 24px
+    );
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15),
+                0 2px 8px rgba(0, 0, 0, 0.1);
     display: grid;
-    min-height: 100%;
     place-items: center;
     font-size: 3rem;
 }
 
+.child-music-card__meta {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+    margin-top: 0.5rem;
+}
+
 .child-music-card__type {
-    display: inline-block;
-    margin-block-end: 0.35rem;
-    font-size: 0.8rem;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
+    display: none;
 }
 
 .child-music-card__title {
-    margin: 0 0 0.35rem;
+    margin: 0;
+    font-size: clamp(1.5rem, 2vw, 2rem);
+    font-weight: 700;
+    color: var(--wp--preset--color--contrast, #241f1a);
+    line-height: 1.2;
+    text-align: center;
 }
 
 .child-music-card__artist,
 .child-music-card__album,
 .child-music-card__year,
 .child-music-card__privacy-note {
-    margin: 0 0 0.5rem;
+    margin: 0;
+    font-size: 1.1rem;
+    font-style: italic;
+    color: color-mix(in srgb, var(--wp--preset--color--contrast, #241f1a) 65%, transparent);
+    text-align: center;
 }
 
 .child-music-card__privacy-note {
+    max-width: 32rem;
+    margin-top: 0.35rem;
     font-size: 0.9rem;
-    opacity: 0.8;
+    font-style: normal;
+}
+
+.child-music-card__preview,
+.child-music-card__audio {
+    width: min(100%, 280px);
 }
 
 .child-music-card__preview-button,
@@ -64,7 +99,7 @@
     align-items: center;
     justify-content: center;
     margin-block-start: 0.5rem;
-    padding: 0.55rem 0.8rem;
+    padding: 0.45rem 0.75rem;
     border: 1px solid currentColor;
     border-radius: 999px;
     background: transparent;
@@ -73,24 +108,17 @@
     line-height: 1.2;
     text-decoration: none;
     cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.child-music-card__provider-link {
-    margin-inline-start: 0.5rem;
+.child-music-card__preview-button:hover,
+.child-music-card__preview-button:focus-visible,
+.child-music-card__provider-link:hover,
+.child-music-card__provider-link:focus-visible {
+    transform: translateY(-2px);
 }
 
 .child-music-card__audio {
     display: block;
-    width: 100%;
     margin-block-start: 0.75rem;
-}
-
-@media (max-width: 600px) {
-    .child-music-card {
-        grid-template-columns: 1fr;
-    }
-
-    .child-music-card__media {
-        max-width: 220px;
-    }
 }

--- a/blocks/music-recommendation/style.css
+++ b/blocks/music-recommendation/style.css
@@ -17,6 +17,7 @@
     background: #fff;
     display: flex;
     justify-content: center;
+    overflow: hidden;
 }
 
 .child-music-card__cover {
@@ -49,6 +50,53 @@
     font-size: 3rem;
 }
 
+.child-music-card__preview-button {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    border-radius: 10px;
+    background: rgba(0, 0, 0, 0);
+    color: #fff;
+    opacity: 0;
+    cursor: pointer;
+    transition: opacity 0.2s ease, background-color 0.2s ease;
+}
+
+.child-music-card__media:hover .child-music-card__preview-button,
+.child-music-card__preview-button:focus-visible,
+.child-music-card__preview-button.is-playing {
+    opacity: 1;
+    background: rgba(0, 0, 0, 0.28);
+}
+
+.child-music-card__preview-icon {
+    display: grid;
+    width: 4rem;
+    height: 4rem;
+    place-items: center;
+    border: 2px solid currentColor;
+    border-radius: 999px;
+    background: rgba(0, 0, 0, 0.42);
+    font-size: 1.8rem;
+    line-height: 1;
+    text-indent: 0.12em;
+}
+
+.child-music-card__preview-button.is-playing .child-music-card__preview-icon {
+    text-indent: 0;
+}
+
+.child-music-card__audio {
+    display: none;
+}
+
 .child-music-card__meta {
     display: flex;
     flex-direction: column;
@@ -72,8 +120,7 @@
 
 .child-music-card__artist,
 .child-music-card__album,
-.child-music-card__year,
-.child-music-card__privacy-note {
+.child-music-card__year {
     margin: 0;
     font-size: 1.1rem;
     font-style: italic;
@@ -81,44 +128,9 @@
     text-align: center;
 }
 
-.child-music-card__privacy-note {
-    max-width: 32rem;
-    margin-top: 0.35rem;
-    font-size: 0.9rem;
-    font-style: normal;
-}
-
-.child-music-card__preview,
-.child-music-card__audio {
-    width: min(100%, 280px);
-}
-
-.child-music-card__preview-button,
-.child-music-card__provider-link {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    margin-block-start: 0.5rem;
-    padding: 0.45rem 0.75rem;
-    border: 1px solid currentColor;
-    border-radius: 999px;
-    background: transparent;
-    color: inherit;
-    font: inherit;
-    line-height: 1.2;
-    text-decoration: none;
-    cursor: pointer;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.child-music-card__preview-button:hover,
-.child-music-card__preview-button:focus-visible,
-.child-music-card__provider-link:hover,
-.child-music-card__provider-link:focus-visible {
-    transform: translateY(-2px);
-}
-
-.child-music-card__audio {
-    display: block;
-    margin-block-start: 0.75rem;
+@media (hover: none) {
+    .child-music-card__preview-button {
+        opacity: 1;
+        background: rgba(0, 0, 0, 0.16);
+    }
 }

--- a/blocks/music-recommendation/style.css
+++ b/blocks/music-recommendation/style.css
@@ -1,0 +1,96 @@
+.wp-block-child-music-recommendation {
+    margin: 1.5rem 0;
+}
+
+.child-music-card {
+    display: grid;
+    grid-template-columns: minmax(120px, 180px) 1fr;
+    gap: 1.25rem;
+    align-items: start;
+    padding: 1rem;
+    border: 1px solid currentColor;
+    border-radius: 0.75rem;
+}
+
+.child-music-card__media {
+    aspect-ratio: 1;
+    background: rgba(0, 0, 0, 0.08);
+    border-radius: 0.5rem;
+    overflow: hidden;
+}
+
+.child-music-card__cover {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.child-music-card__placeholder {
+    display: grid;
+    min-height: 100%;
+    place-items: center;
+    font-size: 3rem;
+}
+
+.child-music-card__type {
+    display: inline-block;
+    margin-block-end: 0.35rem;
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.child-music-card__title {
+    margin: 0 0 0.35rem;
+}
+
+.child-music-card__artist,
+.child-music-card__album,
+.child-music-card__year,
+.child-music-card__privacy-note {
+    margin: 0 0 0.5rem;
+}
+
+.child-music-card__privacy-note {
+    font-size: 0.9rem;
+    opacity: 0.8;
+}
+
+.child-music-card__preview-button,
+.child-music-card__provider-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-block-start: 0.5rem;
+    padding: 0.55rem 0.8rem;
+    border: 1px solid currentColor;
+    border-radius: 999px;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    line-height: 1.2;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.child-music-card__provider-link {
+    margin-inline-start: 0.5rem;
+}
+
+.child-music-card__audio {
+    display: block;
+    width: 100%;
+    margin-block-start: 0.75rem;
+}
+
+@media (max-width: 600px) {
+    .child-music-card {
+        grid-template-columns: 1fr;
+    }
+
+    .child-music-card__media {
+        max-width: 220px;
+    }
+}

--- a/blocks/music-recommendation/view.js
+++ b/blocks/music-recommendation/view.js
@@ -18,4 +18,11 @@ document.addEventListener('click', (event) => {
 
     preview.replaceChildren(audio);
     audio.focus();
+
+    const playPromise = audio.play();
+    if (playPromise?.catch) {
+        playPromise.catch(() => {
+            // Keep the controls visible when the browser refuses immediate playback.
+        });
+    }
 });

--- a/blocks/music-recommendation/view.js
+++ b/blocks/music-recommendation/view.js
@@ -1,0 +1,21 @@
+document.addEventListener('click', (event) => {
+    const button = event.target.closest('.child-music-card__preview-button');
+    if (!button) {
+        return;
+    }
+
+    const preview = button.closest('.child-music-card__preview');
+    const previewUrl = preview?.dataset?.previewUrl;
+    if (!preview || !previewUrl) {
+        return;
+    }
+
+    const audio = document.createElement('audio');
+    audio.controls = true;
+    audio.preload = 'none';
+    audio.src = previewUrl;
+    audio.className = 'child-music-card__audio';
+
+    preview.replaceChildren(audio);
+    audio.focus();
+});

--- a/blocks/music-recommendation/view.js
+++ b/blocks/music-recommendation/view.js
@@ -4,25 +4,52 @@ document.addEventListener('click', (event) => {
         return;
     }
 
-    const preview = button.closest('.child-music-card__preview');
-    const previewUrl = preview?.dataset?.previewUrl;
-    if (!preview || !previewUrl) {
+    const previewUrl = button.dataset?.previewUrl;
+    if (!previewUrl) {
         return;
     }
 
-    const audio = document.createElement('audio');
-    audio.controls = true;
-    audio.preload = 'none';
-    audio.src = previewUrl;
-    audio.className = 'child-music-card__audio';
+    let audio = button.querySelector('audio');
+    const icon = button.querySelector('.child-music-card__preview-icon');
 
-    preview.replaceChildren(audio);
-    audio.focus();
+    if (!audio) {
+        audio = document.createElement('audio');
+        audio.preload = 'none';
+        audio.src = previewUrl;
+        audio.className = 'child-music-card__audio';
+        button.appendChild(audio);
+
+        audio.addEventListener('ended', () => {
+            button.classList.remove('is-playing');
+            button.setAttribute('aria-pressed', 'false');
+            button.setAttribute('aria-label', button.dataset.playLabel || 'Hörprobe abspielen');
+            if (icon) {
+                icon.textContent = '▶';
+            }
+        });
+    }
+
+    const setPlaying = (isPlaying) => {
+        button.classList.toggle('is-playing', isPlaying);
+        button.setAttribute('aria-pressed', isPlaying ? 'true' : 'false');
+        button.setAttribute('aria-label', isPlaying ? (button.dataset.pauseLabel || 'Hörprobe pausieren') : (button.dataset.playLabel || 'Hörprobe abspielen'));
+        if (icon) {
+            icon.textContent = isPlaying ? '❚❚' : '▶';
+        }
+    };
+
+    if (!audio.paused) {
+        audio.pause();
+        setPlaying(false);
+        return;
+    }
 
     const playPromise = audio.play();
+    setPlaying(true);
+
     if (playPromise?.catch) {
         playPromise.catch(() => {
-            // Keep the controls visible when the browser refuses immediate playback.
+            setPlaying(false);
         });
     }
 });

--- a/inc/bootstrap.php
+++ b/inc/bootstrap.php
@@ -17,7 +17,7 @@ add_action( 'wp_enqueue_scripts', 'child_enqueue_theme_styles' );
  * Load modular includes from /inc.
  */
 function child_load_modules(): void {
-	$cache_key = 'child_inc_files_v2_' . CHILD_THEME_VERSION;
+	$cache_key = 'child_inc_files_v3_' . CHILD_THEME_VERSION;
 	$inc_files = wp_cache_get( $cache_key, 'child_theme' );
 
 	$build_module_list = static function(): array {

--- a/inc/media-cover-grid-dedupe.php
+++ b/inc/media-cover-grid-dedupe.php
@@ -24,6 +24,10 @@ function child_get_media_cover_grid_dedupe_key( array $item ): string {
 		return 'game:rawg:' . (int) $item['rawgId'];
 	}
 
+	if ( 'music' === $type && ! empty( $item['providerId'] ) ) {
+		return 'music:provider:' . child_normalize_media_cover_grid_key_part( (string) $item['providerId'] );
+	}
+
 	if ( 'book' === $type && '' !== $title ) {
 		$author = $meta;
 

--- a/inc/media-cover-grid-normalizers.php
+++ b/inc/media-cover-grid-normalizers.php
@@ -15,6 +15,7 @@ function child_get_media_cover_grid_normalizers(): array {
 		'child/book-rating' => 'child_normalize_media_cover_grid_book_block',
 		'child/media-recommendation' => 'child_normalize_media_cover_grid_media_recommendation_block',
 		'child/videogame-recommendation' => 'child_normalize_media_cover_grid_videogame_block',
+		'child/music-recommendation' => 'child_normalize_media_cover_grid_music_block',
 	];
 
 	/**
@@ -126,6 +127,34 @@ function child_normalize_media_cover_grid_videogame_block( array $attrs ): ?arra
 		'coverUrl'    => esc_url_raw( (string) ( $attrs['coverUrl'] ?? '' ) ),
 		'externalUrl' => esc_url_raw( (string) ( $attrs['shopUrl'] ?? '' ) ),
 		'rawgId'      => absint( $attrs['rawgId'] ?? 0 ),
+	];
+}
+
+
+/**
+ * Normalize music recommendation block attributes.
+ *
+ * @param array<string, mixed> $attrs Parsed block attributes.
+ * @return array<string, mixed>|null
+ */
+function child_normalize_media_cover_grid_music_block( array $attrs ): ?array {
+	$title = trim( (string) ( $attrs['title'] ?? '' ) );
+	if ( '' === $title ) {
+		return null;
+	}
+
+	$artist       = trim( (string) ( $attrs['artist'] ?? '' ) );
+	$album_title  = trim( (string) ( $attrs['albumTitle'] ?? '' ) );
+	$release_year = trim( (string) ( $attrs['releaseYear'] ?? '' ) );
+	$meta_parts   = array_filter( [ $artist, 'song' === ( $attrs['musicType'] ?? '' ) ? $album_title : '', $release_year ] );
+
+	return [
+		'type'        => 'music',
+		'title'       => $title,
+		'meta'        => implode( ' · ', $meta_parts ),
+		'coverUrl'    => esc_url_raw( (string) ( $attrs['coverUrl'] ?? '' ) ),
+		'externalUrl' => esc_url_raw( (string) ( $attrs['providerUrl'] ?? '' ) ),
+		'providerId'  => sanitize_text_field( (string) ( $attrs['providerId'] ?? '' ) ),
 	];
 }
 

--- a/inc/media-cover-grid.php
+++ b/inc/media-cover-grid.php
@@ -19,6 +19,7 @@ function child_get_media_cover_grid_type_label( string $type ): string {
 		'movie' => __( 'Film', 'child' ),
 		'tv'    => __( 'Serie', 'child' ),
 		'game'  => __( 'Videospiel', 'child' ),
+		'music' => __( 'Musik', 'child' ),
 	];
 
 	return $labels[ $type ] ?? __( 'Medium', 'child' );

--- a/inc/music-recommendation.php
+++ b/inc/music-recommendation.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Music recommendation integration (Apple/iTunes Search API + REST).
+ *
+ * @package TwentyTwentyFiveChild
+ */
+
+/**
+ * Register a REST endpoint for music searches.
+ */
+function child_register_music_lookup_route(): void {
+	register_rest_route(
+		'child/v1',
+		'/music',
+		[
+			'methods'             => 'GET',
+			'permission_callback' => static function(): bool {
+				return current_user_can( 'edit_posts' );
+			},
+			'args'                => [
+				'q'         => [
+					'required'          => true,
+					'sanitize_callback' => 'sanitize_text_field',
+				],
+				'musicType' => [
+					'required'          => false,
+					'default'           => 'song',
+					'sanitize_callback' => 'sanitize_key',
+				],
+			],
+			'callback'            => 'child_music_lookup_callback',
+		]
+	);
+}
+add_action( 'rest_api_init', 'child_register_music_lookup_route' );
+
+/**
+ * Handle Apple/iTunes music lookups via the REST API.
+ *
+ * @param WP_REST_Request $request Request data.
+ * @return WP_REST_Response|WP_Error
+ */
+function child_music_lookup_callback( WP_REST_Request $request ) {
+	$query      = trim( (string) $request->get_param( 'q' ) );
+	$music_type = 'album' === $request->get_param( 'musicType' ) ? 'album' : 'song';
+
+	if ( '' === $query ) {
+		return new WP_Error( 'missing_query', __( 'Bitte gib einen Suchbegriff ein.', 'child' ), [ 'status' => 400 ] );
+	}
+
+	$country = substr( (string) get_locale(), 3, 2 );
+	$country = preg_match( '/^[A-Z]{2}$/', $country ) ? $country : 'DE';
+	$entity  = 'album' === $music_type ? 'album' : 'song';
+
+	$api_url = add_query_arg(
+		[
+			'term'    => $query,
+			'media'   => 'music',
+			'entity'  => $entity,
+			'country' => $country,
+			'limit'   => 10,
+		],
+		'https://itunes.apple.com/search'
+	);
+
+	$response = wp_safe_remote_get(
+		$api_url,
+		[
+			'timeout' => 8,
+		]
+	);
+
+	if ( is_wp_error( $response ) ) {
+		return new WP_Error( 'music_lookup_failed', __( 'Die Musiksuche konnte nicht geladen werden.', 'child' ), [ 'status' => 500 ] );
+	}
+
+	$status = wp_remote_retrieve_response_code( $response );
+	if ( $status < 200 || $status >= 300 ) {
+		return new WP_Error( 'music_lookup_failed', __( 'Die Musiksuche konnte nicht geladen werden.', 'child' ), [ 'status' => $status ] );
+	}
+
+	$data = json_decode( wp_remote_retrieve_body( $response ), true );
+	if ( ! is_array( $data ) ) {
+		return new WP_Error( 'invalid_response', __( 'Die Musiksuche lieferte keine gültige Antwort.', 'child' ), [ 'status' => 500 ] );
+	}
+
+	$results = array_values(
+		array_filter(
+			array_map(
+				static function( array $item ) use ( $music_type ): ?array {
+					$title = 'album' === $music_type ? (string) ( $item['collectionName'] ?? '' ) : (string) ( $item['trackName'] ?? '' );
+					if ( '' === trim( $title ) ) {
+						return null;
+					}
+
+					$release_date = (string) ( $item['releaseDate'] ?? '' );
+					$release_year = '';
+					if ( '' !== $release_date ) {
+						$timestamp    = strtotime( $release_date );
+						$release_year = $timestamp ? gmdate( 'Y', $timestamp ) : '';
+					}
+
+					$artwork = (string) ( $item['artworkUrl100'] ?? '' );
+					if ( '' !== $artwork ) {
+						$artwork = str_replace( '100x100bb', '600x600bb', $artwork );
+					}
+
+					return [
+						'id'          => (string) ( 'album' === $music_type ? ( $item['collectionId'] ?? '' ) : ( $item['trackId'] ?? '' ) ),
+						'musicType'   => $music_type,
+						'title'       => $title,
+						'artist'      => (string) ( $item['artistName'] ?? '' ),
+						'albumTitle'  => (string) ( $item['collectionName'] ?? '' ),
+						'releaseYear' => $release_year,
+						'coverUrl'    => esc_url_raw( $artwork ),
+						'provider'    => 'Apple/iTunes',
+						'providerUrl' => esc_url_raw( (string) ( 'album' === $music_type ? ( $item['collectionViewUrl'] ?? '' ) : ( $item['trackViewUrl'] ?? '' ) ) ),
+						'previewUrl'  => 'song' === $music_type ? esc_url_raw( (string) ( $item['previewUrl'] ?? '' ) ) : '',
+					];
+				},
+				is_array( $data['results'] ?? null ) ? $data['results'] : []
+			)
+		)
+	);
+
+	return rest_ensure_response( [ 'results' => $results ] );
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable music recommendation block with preview and legal-safe playback and add music as a supported media type for the existing Media Cover Grid.
- Allow editors to search music via an internal REST lookup and normalize results into the shared media items so music appears alongside books, films and games.

### Description
- Add a new block `child/music-recommendation` including `block.json`, editor `index.js`, `editor.css`, `style.css`, `view.js` and server `render.php` to provide search, selection, preview and frontend lazy-loaded audio playback.
- Register a REST endpoint in `inc/music-recommendation.php` (`/child/v1/music`) that queries the Apple/iTunes Search API and returns normalized results for the block editor.
- Integrate music into the Media Cover Grid by updating `blocks/index.js` to import `music-recommendation`, by adding `music` to `blocks/media-cover-grid/block.json` defaults and description, and by extending `blocks/media-cover-grid/index.js` preview/options and `render.php` default media types.
- Extend media-cover-grid internals to support music by adding a normalizer `child_normalize_media_cover_grid_music_block` in `inc/media-cover-grid-normalizers.php`, adding `music` to the type labels in `inc/media-cover-grid.php`, and including music provider dedupe logic in `inc/media-cover-grid-dedupe.php` to use `providerId` for stable keys.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a797f092883259f432984650bb3e3)