### PR TITLE
Add selectable cover formats to Media Cover Grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A production-focused child theme for **Twenty Twenty-Five** that keeps customiza
 .
 ├── assets/                      # Reserved for custom static assets.
 ├── blocks/                      # Block source files (editor JS/CSS + render callbacks).
+│   └── shared/                  # Shared block-editor utilities used by multiple blocks.
 ├── build/                       # Compiled block assets used by register_block_type().
 ├── releases/                    # Versioned release notes.
 ├── inc/
@@ -16,7 +17,11 @@ A production-focused child theme for **Twenty Twenty-Five** that keeps customiza
 │   ├── book-rating.php
 │   ├── head-footer-injections.php
 │   ├── human-json.php
+│   ├── media-cover-grid.php
+│   ├── media-cover-grid-dedupe.php
+│   ├── media-cover-grid-normalizers.php
 │   ├── media-recommendation.php
+│   ├── music-recommendation.php
 │   ├── notes.php
 │   ├── post-likes.php
 │   ├── rss-feed-footer.php
@@ -39,7 +44,9 @@ A production-focused child theme for **Twenty Twenty-Five** that keeps customiza
 
 - `child/book-rating`
 - `child/magic-cards`
+- `child/media-cover-grid`
 - `child/media-recommendation`
+- `child/music-recommendation`
 - `child/pixelfed-feed`
 - `child/popular-posts`
 - `child/post-likes`
@@ -57,6 +64,7 @@ Each block:
 When adding or changing a dynamic block, mirror the existing examples in `blocks/post-likes`, `blocks/media-cover-grid`, and `blocks/media-recommendation`:
 
 - Put block-owned assets under `blocks/{slug}/`. A feature should include `block.json` and `index.js`, then add `render.php` for dynamic output, `style.css` for front-end styles, `editor.css` for editor-only styles, and `view.js` only when the front end needs interactive behavior.
+- Put shared editor-only helpers under `blocks/shared/` when multiple block editors need the same state or UI primitive. Current shared media helpers cover search state, search feedback, and reusable search-result row rendering.
 - Put server-side helper modules in `inc/{slug}.php`. Keep `blocks/{slug}/render.php` focused on rendering sanitized markup and delegate reusable queries, REST/AJAX handlers, settings, cache helpers, and data normalization to the matching `inc/` file.
 - Expose render-time behavior through stable, public `child_*` functions instead of anonymous helper logic that other blocks cannot reuse. For example, `blocks/media-cover-grid/render.php` calls the public helpers from `inc/media-cover-grid.php`, while `blocks/post-likes/render.php` reads counts through the post-likes helper API.
 - Localize editor data from `inc/blocks.php` with `child_localize_block_editor_script( $block_name, $object_name, $data )` on `enqueue_block_editor_assets`, as `inc/media-recommendation.php` does for the Media Recommendation editor AJAX URL and nonce.
@@ -64,17 +72,50 @@ When adding or changing a dynamic block, mirror the existing examples in `blocks
 
 ## API-Backed Features
 
+### Media Recommendation Blocks
+
+The recommendation blocks keep their saved attribute schemas independent, but share editor primitives where possible:
+
+- `blocks/shared/media/useSearchState.js` centralizes search term, loading, result, selection, and error state.
+- `blocks/shared/media/SearchFeedback.js` centralizes loading/error output.
+- `blocks/shared/media/SearchResultsList.js` centralizes result row button rendering while each block keeps its own result markup and CSS classes.
+- Provider-specific search and mapping stays in each feature block so Books, TMDB, Apple/iTunes, and RAWG can evolve independently.
+
+### Media Cover Grid
+
+`child/media-cover-grid` auto-builds a cover grid from published recommendation blocks. It uses:
+
+- `inc/media-cover-grid.php` for post scanning, caching, and shared grid helpers.
+- `inc/media-cover-grid-normalizers.php` to normalize book, movie/series, videogame, and music block attributes into a shared media item contract.
+- `inc/media-cover-grid-dedupe.php` to merge duplicate recommendations while preserving source-post metadata.
+- `blocks/media-cover-grid/view.js` for front-end filtering. The default filter state is **Alle**, individual media type filters hide empty year sections automatically, and year separators are rendered from each item’s source post year.
+
+The grid intentionally keeps the recommendation block schemas unchanged and treats the grid item shape as a derived view model.
+
+### Book Recommendation (Google Books)
+
+- Admin settings page under **Settings → Book Rating**.
+- API key lookup order: option `child_google_books_api_key`, then `CHILD_GOOGLE_BOOKS_API_KEY` constant fallback.
+- Editor REST endpoint: `/child/v1/books`.
+
 ### Media Recommendation (TMDB)
 
 - Admin settings page under **Settings → Media Recommendation**.
 - API key lookup order: option `child_tmdb_api_key`, then `TMDB_API_KEY` constant fallback.
 - Editor AJAX endpoint: `wp_ajax_child_tmdb_search`.
 
+### Music Recommendation (Apple/iTunes)
+
+- Editor REST endpoint: `/child/v1/music`.
+- Supports songs and albums while only loading audio previews on explicit front-end interaction.
+- Keeps legal/privacy messaging in the block editor.
+
 ### Videogame Recommendation (RAWG)
 
 - Admin settings page under **Settings → Videogame Recommendation**.
 - API key lookup order: option `child_rawg_api_key`, then `RAWG_API_KEY` constant fallback.
 - Editor AJAX endpoint: `wp_ajax_child_rawg_search`.
+- Platform chip display helpers live in `blocks/videogame-recommendation/utils.php` for PHP rendering.
 
 ## RSS Feed Footer
 

--- a/blocks/book-rating/editor.css
+++ b/blocks/book-rating/editor.css
@@ -72,6 +72,41 @@
     color: #3c434a;
 }
 
+.wp-block-child-book-rating .book-search-results {
+    max-width: 100%;
+}
+
+.wp-block-child-book-rating .components-button.book-search-result {
+    display: grid !important;
+    grid-template-columns: 44px minmax(0, 1fr);
+    align-items: center;
+    width: 100%;
+    max-width: 100%;
+    min-height: 82px;
+    overflow: hidden;
+    white-space: normal;
+}
+
+.wp-block-child-book-rating .book-search-result__thumb,
+.wp-block-child-book-rating .book-search-result__thumb img {
+    width: 44px !important;
+    height: 64px !important;
+    max-width: 44px !important;
+    max-height: 64px !important;
+}
+
+.wp-block-child-book-rating .book-search-result__details {
+    min-width: 0;
+    overflow: hidden;
+}
+
+.wp-block-child-book-rating .book-search-result__title,
+.wp-block-child-book-rating .book-search-result__subtitle,
+.wp-block-child-book-rating .book-search-result__author {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .book-preview--empty {
     margin-top: 1.5rem;
     padding: 2rem;

--- a/blocks/book-rating/index.js
+++ b/blocks/book-rating/index.js
@@ -1,11 +1,13 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, TextControl, Button, Spinner, Notice } from '@wordpress/components';
+import { PanelBody, TextControl, Button } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import metadata from './block.json';
+import { SearchFeedback } from '../shared/media/SearchFeedback';
+import { SearchResultsList } from '../shared/media/SearchResultsList';
 import './editor.css';
 import './style.css';
 
@@ -82,19 +84,17 @@ const BookPreview = ({ bookTitle, author, coverUrl, shopUrl }) => {
 };
 
 const SearchResults = ({ results, selectedId, onSelect }) => {
-    if (!results.length) {
-        return null;
-    }
-
     return (
-        <div className="book-search-results">
-            {results.map((book) => (
-                <Button
-                    key={book.id}
-                    variant={book.id === selectedId ? 'primary' : 'secondary'}
-                    onClick={() => onSelect(book)}
-                    className={`book-search-result${book.id === selectedId ? ' is-active' : ''}`}
-                >
+        <SearchResultsList
+            results={results}
+            selectedId={selectedId}
+            onSelect={onSelect}
+            className="book-search-results"
+            getId={(book) => book.id}
+            getClassName={(book, isSelected) => `book-search-result${isSelected ? ' is-active' : ''}`}
+        >
+            {(book) => (
+                <>
                     {book.cover ? (
                         <span className="book-search-result__thumb">
                             <img src={book.cover} alt={book.title || ''} loading="lazy" />
@@ -118,9 +118,9 @@ const SearchResults = ({ results, selectedId, onSelect }) => {
                             </span>
                         ) : null}
                     </span>
-                </Button>
-            ))}
-        </div>
+                </>
+            )}
+        </SearchResultsList>
     );
 };
 
@@ -242,16 +242,11 @@ function Edit({ attributes, setAttributes }) {
                     >
                         {isSearching ? __('Suche...', 'child') : __('Suchen', 'child')}
                     </Button>
-                    {isSearching && (
-                        <div className="book-search-loading">
-                            <Spinner />
-                        </div>
-                    )}
-                    {searchError && (
-                        <Notice status="error" isDismissible={false}>
-                            {searchError}
-                        </Notice>
-                    )}
+                    <SearchFeedback
+                        isSearching={isSearching}
+                        error={searchError}
+                        loadingClassName="book-search-loading"
+                    />
                     {!isSearching && hasSearched && (
                         <SearchResults
                             results={searchResults}

--- a/blocks/media-cover-grid/block.json
+++ b/blocks/media-cover-grid/block.json
@@ -14,6 +14,10 @@
       "type": "array",
       "default": ["book", "movie", "tv", "game", "music"]
     },
+    "coverFormats": {
+      "type": "array",
+      "default": ["portrait", "square", "landscape"]
+    },
     "maxItems": {
       "type": "number",
       "default": 48

--- a/blocks/media-cover-grid/block.json
+++ b/blocks/media-cover-grid/block.json
@@ -49,6 +49,7 @@
   },
   "textdomain": "twentyfivetwentyfivechild",
   "editorScript": "file:./index.js",
+  "viewScript": "file:./view.js",
   "editorStyle": "file:./editor.css",
   "style": "file:./style.css"
 }

--- a/blocks/media-cover-grid/block.json
+++ b/blocks/media-cover-grid/block.json
@@ -14,10 +14,6 @@
       "type": "array",
       "default": ["book", "movie", "tv", "game", "music"]
     },
-    "coverFormats": {
-      "type": "array",
-      "default": ["portrait", "square", "landscape"]
-    },
     "maxItems": {
       "type": "number",
       "default": 48

--- a/blocks/media-cover-grid/editor.css
+++ b/blocks/media-cover-grid/editor.css
@@ -8,24 +8,6 @@
 }
 
 
-.child-media-cover-grid__filter-group,
-.wp-block-child-media-cover-grid .child-media-cover-grid__filter-group,
-.child-media-cover-grid-block .child-media-cover-grid__filter-group {
-  border-block-start: 1px solid color-mix(in srgb, currentColor 14%, transparent);
-  margin-block-start: 0.75rem;
-  padding-block-start: 0.75rem;
-}
-
-.child-media-cover-grid__filter-label,
-.wp-block-child-media-cover-grid .child-media-cover-grid__filter-label,
-.child-media-cover-grid-block .child-media-cover-grid__filter-label {
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  margin: 0 0 0.5rem;
-  text-transform: uppercase;
-}
-
 .wp-block-child-media-cover-grid .child-media-cover-grid__cover,
 .child-media-cover-grid-block .child-media-cover-grid__cover {
   background: linear-gradient(135deg, #f2f0ec, #d7d1c8);

--- a/blocks/media-cover-grid/editor.css
+++ b/blocks/media-cover-grid/editor.css
@@ -7,6 +7,25 @@
   padding: 0.75rem 1rem;
 }
 
+
+.child-media-cover-grid__filter-group,
+.wp-block-child-media-cover-grid .child-media-cover-grid__filter-group,
+.child-media-cover-grid-block .child-media-cover-grid__filter-group {
+  border-block-start: 1px solid color-mix(in srgb, currentColor 14%, transparent);
+  margin-block-start: 0.75rem;
+  padding-block-start: 0.75rem;
+}
+
+.child-media-cover-grid__filter-label,
+.wp-block-child-media-cover-grid .child-media-cover-grid__filter-label,
+.child-media-cover-grid-block .child-media-cover-grid__filter-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin: 0 0 0.5rem;
+  text-transform: uppercase;
+}
+
 .wp-block-child-media-cover-grid .child-media-cover-grid__cover,
 .child-media-cover-grid-block .child-media-cover-grid__cover {
   background: linear-gradient(135deg, #f2f0ec, #d7d1c8);

--- a/blocks/media-cover-grid/index.js
+++ b/blocks/media-cover-grid/index.js
@@ -20,11 +20,6 @@ const MEDIA_TYPE_OPTIONS = [
     { value: 'music', label: __('Musik', 'child') }
 ];
 
-const COVER_FORMAT_OPTIONS = [
-    { value: 'portrait', label: __('Hochformat', 'child') },
-    { value: 'square', label: __('Quadratisch', 'child') },
-    { value: 'landscape', label: __('Querformat', 'child') }
-];
 
 const PREVIEW_ITEMS = [
     {
@@ -64,20 +59,19 @@ const PREVIEW_ITEMS = [
     }
 ];
 
-const updateSelectedValues = (values, value, checked) => {
-    const normalizedValues = Array.isArray(values) ? values : [];
+const updateMediaTypes = (mediaTypes, value, checked) => {
+    const normalizedTypes = Array.isArray(mediaTypes) ? mediaTypes : [];
 
     if (checked) {
-        return [...new Set([...normalizedValues, value])];
+        return [...new Set([...normalizedTypes, value])];
     }
 
-    return normalizedValues.filter((selectedValue) => selectedValue !== value);
+    return normalizedTypes.filter((type) => type !== value);
 };
 
 function Edit({ attributes, setAttributes }) {
     const {
         mediaTypes = metadata.attributes.mediaTypes.default,
-        coverFormats = metadata.attributes.coverFormats.default,
         maxItems = metadata.attributes.maxItems.default,
         linkTo = metadata.attributes.linkTo.default,
         sortOrder = metadata.attributes.sortOrder.default,
@@ -89,10 +83,7 @@ function Edit({ attributes, setAttributes }) {
 
     const blockProps = useBlockProps({ className: 'child-media-cover-grid-block' });
     const enabledTypes = Array.isArray(mediaTypes) ? mediaTypes : [];
-    const enabledFormats = Array.isArray(coverFormats) ? coverFormats : [];
-    const previewItems = PREVIEW_ITEMS.filter(
-        (item) => enabledTypes.includes(item.type) && enabledFormats.includes(item.coverFormat)
-    );
+    const previewItems = PREVIEW_ITEMS.filter((item) => enabledTypes.includes(item.type));
 
     return (
         <div {...blockProps}>
@@ -105,27 +96,11 @@ function Edit({ attributes, setAttributes }) {
                             checked={enabledTypes.includes(option.value)}
                             onChange={(checked) =>
                                 setAttributes({
-                                    mediaTypes: updateSelectedValues(enabledTypes, option.value, checked)
+                                    mediaTypes: updateMediaTypes(enabledTypes, option.value, checked)
                                 })
                             }
                         />
                     ))}
-
-                    <div className="child-media-cover-grid__filter-group">
-                        <p className="child-media-cover-grid__filter-label">{__('Formate', 'child')}</p>
-                        {COVER_FORMAT_OPTIONS.map((option) => (
-                            <CheckboxControl
-                                key={option.value}
-                                label={option.label}
-                                checked={enabledFormats.includes(option.value)}
-                                onChange={(checked) =>
-                                    setAttributes({
-                                        coverFormats: updateSelectedValues(enabledFormats, option.value, checked)
-                                    })
-                                }
-                            />
-                        ))}
-                    </div>
 
                     <RangeControl
                         label={__('Maximale Anzahl', 'child')}
@@ -202,7 +177,7 @@ function Edit({ attributes, setAttributes }) {
                     ))
                 ) : (
                     <p className="child-media-cover-grid__empty">
-                        {__('Wähle mindestens einen Medientyp und ein Format aus.', 'child')}
+                        {__('Wähle mindestens einen Medientyp aus.', 'child')}
                     </p>
                 )}
             </div>

--- a/blocks/media-cover-grid/index.js
+++ b/blocks/media-cover-grid/index.js
@@ -20,52 +20,64 @@ const MEDIA_TYPE_OPTIONS = [
     { value: 'music', label: __('Musik', 'child') }
 ];
 
+const COVER_FORMAT_OPTIONS = [
+    { value: 'portrait', label: __('Hochformat', 'child') },
+    { value: 'square', label: __('Quadratisch', 'child') },
+    { value: 'landscape', label: __('Querformat', 'child') }
+];
+
 const PREVIEW_ITEMS = [
     {
         type: 'book',
+        coverFormat: 'portrait',
         typeLabel: __('Buch', 'child'),
         title: __('Beispielbuch', 'child'),
         meta: __('Autor:in', 'child')
     },
     {
         type: 'movie',
+        coverFormat: 'portrait',
         typeLabel: __('Film', 'child'),
         title: __('Beispielfilm', 'child'),
         meta: '2025'
     },
     {
         type: 'tv',
+        coverFormat: 'portrait',
         typeLabel: __('Serie', 'child'),
         title: __('Beispielserie', 'child'),
         meta: '2024'
     },
     {
         type: 'game',
+        coverFormat: 'landscape',
         typeLabel: __('Videospiel', 'child'),
         title: __('Beispielspiel', 'child'),
         meta: __('PC, Switch', 'child')
     },
     {
         type: 'music',
+        coverFormat: 'square',
         typeLabel: __('Musik', 'child'),
         title: __('Beispielsong', 'child'),
         meta: __('Künstler:in', 'child')
     }
 ];
 
-const updateMediaTypes = (mediaTypes, value, checked) => {
-    const normalizedTypes = Array.isArray(mediaTypes) ? mediaTypes : [];
+const updateSelectedValues = (values, value, checked) => {
+    const normalizedValues = Array.isArray(values) ? values : [];
 
     if (checked) {
-        return [...new Set([...normalizedTypes, value])];
+        return [...new Set([...normalizedValues, value])];
     }
 
-    return normalizedTypes.filter((type) => type !== value);
+    return normalizedValues.filter((selectedValue) => selectedValue !== value);
 };
 
 function Edit({ attributes, setAttributes }) {
     const {
         mediaTypes = metadata.attributes.mediaTypes.default,
+        coverFormats = metadata.attributes.coverFormats.default,
         maxItems = metadata.attributes.maxItems.default,
         linkTo = metadata.attributes.linkTo.default,
         sortOrder = metadata.attributes.sortOrder.default,
@@ -77,7 +89,10 @@ function Edit({ attributes, setAttributes }) {
 
     const blockProps = useBlockProps({ className: 'child-media-cover-grid-block' });
     const enabledTypes = Array.isArray(mediaTypes) ? mediaTypes : [];
-    const previewItems = PREVIEW_ITEMS.filter((item) => enabledTypes.includes(item.type));
+    const enabledFormats = Array.isArray(coverFormats) ? coverFormats : [];
+    const previewItems = PREVIEW_ITEMS.filter(
+        (item) => enabledTypes.includes(item.type) && enabledFormats.includes(item.coverFormat)
+    );
 
     return (
         <div {...blockProps}>
@@ -90,11 +105,28 @@ function Edit({ attributes, setAttributes }) {
                             checked={enabledTypes.includes(option.value)}
                             onChange={(checked) =>
                                 setAttributes({
-                                    mediaTypes: updateMediaTypes(enabledTypes, option.value, checked)
+                                    mediaTypes: updateSelectedValues(enabledTypes, option.value, checked)
                                 })
                             }
                         />
                     ))}
+
+                    <div className="child-media-cover-grid__filter-group">
+                        <p className="child-media-cover-grid__filter-label">{__('Formate', 'child')}</p>
+                        {COVER_FORMAT_OPTIONS.map((option) => (
+                            <CheckboxControl
+                                key={option.value}
+                                label={option.label}
+                                checked={enabledFormats.includes(option.value)}
+                                onChange={(checked) =>
+                                    setAttributes({
+                                        coverFormats: updateSelectedValues(enabledFormats, option.value, checked)
+                                    })
+                                }
+                            />
+                        ))}
+                    </div>
+
                     <RangeControl
                         label={__('Maximale Anzahl', 'child')}
                         value={maxItems}
@@ -156,7 +188,7 @@ function Edit({ attributes, setAttributes }) {
                 {previewItems.length ? (
                     previewItems.map((item) => (
                         <div key={item.type} className="child-media-cover-grid__item">
-                            <div className={`child-media-cover-grid__cover child-media-cover-grid__cover--${item.type}`} aria-hidden="true">
+                            <div className={`child-media-cover-grid__cover child-media-cover-grid__cover--${item.type} child-media-cover-grid__cover--${item.coverFormat}`} aria-hidden="true">
                                 <span>{item.typeLabel.charAt(0)}</span>
                             </div>
                             {(showType || showTitle || showMeta) && (
@@ -170,7 +202,7 @@ function Edit({ attributes, setAttributes }) {
                     ))
                 ) : (
                     <p className="child-media-cover-grid__empty">
-                        {__('Wähle mindestens einen Medientyp aus.', 'child')}
+                        {__('Wähle mindestens einen Medientyp und ein Format aus.', 'child')}
                     </p>
                 )}
             </div>

--- a/blocks/media-cover-grid/index.js
+++ b/blocks/media-cover-grid/index.js
@@ -162,7 +162,7 @@ function Edit({ attributes, setAttributes }) {
             <div className="child-media-cover-grid">
                 {previewItems.length ? (
                     previewItems.map((item) => (
-                        <div key={item.type} className="child-media-cover-grid__item">
+                        <div key={item.type} className={`child-media-cover-grid__item child-media-cover-grid__item--${item.type}`}>
                             <div className={`child-media-cover-grid__cover child-media-cover-grid__cover--${item.type} child-media-cover-grid__cover--${item.coverFormat}`} aria-hidden="true">
                                 <span>{item.typeLabel.charAt(0)}</span>
                             </div>

--- a/blocks/media-cover-grid/render.php
+++ b/blocks/media-cover-grid/render.php
@@ -77,8 +77,11 @@ return function( array $attributes ): string {
 				<div class="child-media-cover-grid__controls" aria-label="<?php echo esc_attr__( 'Medien filtern', 'child' ); ?>">
 					<div class="child-media-cover-grid__control-group" role="group" aria-label="<?php echo esc_attr__( 'Medientypen', 'child' ); ?>">
 						<span class="child-media-cover-grid__control-label"><?php echo esc_html__( 'Typ', 'child' ); ?></span>
+						<button class="child-media-cover-grid__filter is-active" type="button" data-child-media-filter-group="type" data-child-media-filter-value="all" aria-pressed="true">
+							<?php echo esc_html__( 'Alle', 'child' ); ?>
+						</button>
 						<?php foreach ( $item_types as $item_type ) : ?>
-							<button class="child-media-cover-grid__filter is-active" type="button" data-child-media-filter-group="type" data-child-media-filter-value="<?php echo esc_attr( $item_type ); ?>" aria-pressed="true">
+							<button class="child-media-cover-grid__filter" type="button" data-child-media-filter-group="type" data-child-media-filter-value="<?php echo esc_attr( $item_type ); ?>" aria-pressed="false">
 								<?php echo esc_html( child_get_media_cover_grid_type_label( $item_type ) ); ?>
 							</button>
 						<?php endforeach; ?>
@@ -87,6 +90,7 @@ return function( array $attributes ): string {
 			<?php endif; ?>
 			<p class="child-media-cover-grid__empty child-media-cover-grid__empty--filtered" hidden><?php echo esc_html__( 'Keine Medien für diese Filter gefunden.', 'child' ); ?></p>
 			<div class="child-media-cover-grid" role="list">
+				<?php $current_year = null; ?>
 				<?php foreach ( $items as $item ) : ?>
 					<?php
 					$link_url     = '';
@@ -99,6 +103,8 @@ return function( array $attributes ): string {
 					$cover_format = child_get_media_cover_grid_cover_format( $item );
 					$type_label   = child_get_media_cover_grid_type_label( $type );
 					$source_title  = (string) ( $item['sourcePostTitle'] ?? '' );
+					$source_timestamp = (int) ( $item['sourcePostTimestamp'] ?? 0 );
+					$item_year        = $source_timestamp ? wp_date( 'Y', $source_timestamp ) : esc_html__( 'Unbekannt', 'child' );
 					$mention_count = max( 1, absint( $item['mentionCount'] ?? 1 ) );
 
 					if ( 'post' === $link_to ) {
@@ -111,6 +117,12 @@ return function( array $attributes ): string {
 
 					$tag_name = $link_url ? 'a' : 'div';
 					?>
+					<?php if ( $item_year !== $current_year ) : ?>
+						<div class="child-media-cover-grid__year" data-child-media-year="<?php echo esc_attr( $item_year ); ?>" aria-hidden="false">
+							<span class="child-media-cover-grid__year-label"><?php echo esc_html( $item_year ); ?></span>
+						</div>
+						<?php $current_year = $item_year; ?>
+					<?php endif; ?>
 					<<?php echo tag_escape( $tag_name ); ?> class="child-media-cover-grid__item child-media-cover-grid__item--<?php echo esc_attr( $type ); ?>" data-child-media-type="<?php echo esc_attr( $type ); ?>"<?php echo $link_url ? ' href="' . esc_url( $link_url ) . '"' . $link_target . $link_rel : ''; ?> role="listitem" aria-label="<?php echo esc_attr( $title ); ?>">
 						<div class="child-media-cover-grid__cover child-media-cover-grid__cover--<?php echo esc_attr( $cover_format ); ?>">
 							<?php if ( $cover_url ) : ?>

--- a/blocks/media-cover-grid/render.php
+++ b/blocks/media-cover-grid/render.php
@@ -64,6 +64,28 @@ return function( array $attributes ): string {
 	);
 
 	$items = array_slice( $items, 0, $max_items );
+	$item_types = array_values(
+		array_filter(
+			array_unique(
+				array_map(
+					static function( array $item ): string {
+						return (string) ( $item['type'] ?? '' );
+					},
+					$items
+				)
+			)
+		)
+	);
+	$item_formats = array_values(
+		array_unique(
+			array_map(
+				static function( array $item ): string {
+					return child_get_media_cover_grid_cover_format( $item );
+				},
+				$items
+			)
+		)
+	);
 
 	ob_start();
 	?>
@@ -71,6 +93,30 @@ return function( array $attributes ): string {
 		<?php if ( [] === $items ) : ?>
 			<p class="child-media-cover-grid__empty"><?php echo esc_html__( 'Noch keine Medien gefunden.', 'child' ); ?></p>
 		<?php else : ?>
+			<div class="child-media-cover-grid__controls" aria-label="<?php echo esc_attr__( 'Medien filtern', 'child' ); ?>">
+				<?php if ( count( $item_types ) > 1 ) : ?>
+					<div class="child-media-cover-grid__control-group" role="group" aria-label="<?php echo esc_attr__( 'Medientypen', 'child' ); ?>">
+						<span class="child-media-cover-grid__control-label"><?php echo esc_html__( 'Typ', 'child' ); ?></span>
+						<?php foreach ( $item_types as $item_type ) : ?>
+							<button class="child-media-cover-grid__filter is-active" type="button" data-child-media-filter-group="type" data-child-media-filter-value="<?php echo esc_attr( $item_type ); ?>" aria-pressed="true">
+								<?php echo esc_html( child_get_media_cover_grid_type_label( $item_type ) ); ?>
+							</button>
+						<?php endforeach; ?>
+					</div>
+				<?php endif; ?>
+
+				<?php if ( count( $item_formats ) > 1 ) : ?>
+					<div class="child-media-cover-grid__control-group" role="group" aria-label="<?php echo esc_attr__( 'Cover-Formate', 'child' ); ?>">
+						<span class="child-media-cover-grid__control-label"><?php echo esc_html__( 'Format', 'child' ); ?></span>
+						<?php foreach ( $item_formats as $item_format ) : ?>
+							<button class="child-media-cover-grid__filter is-active" type="button" data-child-media-filter-group="format" data-child-media-filter-value="<?php echo esc_attr( $item_format ); ?>" aria-pressed="true">
+								<?php echo esc_html( child_get_media_cover_grid_cover_format_label( $item_format ) ); ?>
+							</button>
+						<?php endforeach; ?>
+					</div>
+				<?php endif; ?>
+			</div>
+			<p class="child-media-cover-grid__empty child-media-cover-grid__empty--filtered" hidden><?php echo esc_html__( 'Keine Medien für diese Filter gefunden.', 'child' ); ?></p>
 			<div class="child-media-cover-grid" role="list">
 				<?php foreach ( $items as $item ) : ?>
 					<?php
@@ -96,7 +142,7 @@ return function( array $attributes ): string {
 
 					$tag_name = $link_url ? 'a' : 'div';
 					?>
-					<<?php echo tag_escape( $tag_name ); ?> class="child-media-cover-grid__item child-media-cover-grid__item--<?php echo esc_attr( $type ); ?>"<?php echo $link_url ? ' href="' . esc_url( $link_url ) . '"' . $link_target . $link_rel : ''; ?> role="listitem" aria-label="<?php echo esc_attr( $title ); ?>">
+					<<?php echo tag_escape( $tag_name ); ?> class="child-media-cover-grid__item child-media-cover-grid__item--<?php echo esc_attr( $type ); ?>" data-child-media-type="<?php echo esc_attr( $type ); ?>" data-child-media-format="<?php echo esc_attr( $cover_format ); ?>"<?php echo $link_url ? ' href="' . esc_url( $link_url ) . '"' . $link_target . $link_rel : ''; ?> role="listitem" aria-label="<?php echo esc_attr( $title ); ?>">
 						<div class="child-media-cover-grid__cover child-media-cover-grid__cover--<?php echo esc_attr( $cover_format ); ?>">
 							<?php if ( $cover_url ) : ?>
 								<img src="<?php echo esc_url( $cover_url ); ?>" alt="<?php echo esc_attr( $title ); ?>" loading="lazy" />

--- a/blocks/media-cover-grid/render.php
+++ b/blocks/media-cover-grid/render.php
@@ -11,8 +11,11 @@ return function( array $attributes ): string {
 	}
 
 	$default_types     = [ 'book', 'movie', 'tv', 'game', 'music' ];
+	$default_formats   = [ 'portrait', 'square', 'landscape' ];
 	$media_types       = $attributes['mediaTypes'] ?? $default_types;
 	$allowed_types     = array_values( array_intersect( $default_types, is_array( $media_types ) ? $media_types : $default_types ) );
+	$cover_formats     = $attributes['coverFormats'] ?? $default_formats;
+	$allowed_formats   = array_values( array_intersect( $default_formats, is_array( $cover_formats ) ? $cover_formats : $default_formats ) );
 	$max_items         = max( 1, min( 120, absint( $attributes['maxItems'] ?? 48 ) ) );
 	$link_to           = in_array( $attributes['linkTo'] ?? 'post', [ 'post', 'external', 'none' ], true ) ? $attributes['linkTo'] : 'post';
 	$sort_order        = in_array( $attributes['sortOrder'] ?? 'newest', [ 'newest', 'oldest', 'title' ], true ) ? $attributes['sortOrder'] : 'newest';
@@ -21,11 +24,15 @@ return function( array $attributes ): string {
 	$show_type         = (bool) ( $attributes['showType'] ?? true );
 	$allow_duplicates  = (bool) ( $attributes['allowDuplicates'] ?? false );
 
-	if ( [] === $allowed_types ) {
+	if ( [] === $allowed_types || [] === $allowed_formats ) {
+		$empty_message = [] === $allowed_types
+			? esc_html__( 'Bitte wähle mindestens einen Medientyp aus.', 'child' )
+			: esc_html__( 'Bitte wähle mindestens ein Format aus.', 'child' );
+
 		return sprintf(
 			'<div %s><p class="child-media-cover-grid__empty">%s</p></div>',
 			get_block_wrapper_attributes( [ 'class' => 'child-media-cover-grid-block' ] ),
-			esc_html__( 'Bitte wähle mindestens einen Medientyp aus.', 'child' )
+			$empty_message
 		);
 	}
 
@@ -33,8 +40,11 @@ return function( array $attributes ): string {
 	$items = array_values(
 		array_filter(
 			$items,
-			static function( array $item ) use ( $allowed_types ): bool {
-				return in_array( $item['type'] ?? '', $allowed_types, true );
+			static function( array $item ) use ( $allowed_types, $allowed_formats ): bool {
+				$type         = (string) ( $item['type'] ?? '' );
+				$cover_format = child_get_media_cover_grid_cover_format( $item );
+
+				return in_array( $type, $allowed_types, true ) && in_array( $cover_format, $allowed_formats, true );
 			}
 		)
 	);
@@ -71,6 +81,7 @@ return function( array $attributes ): string {
 					$title        = (string) ( $item['title'] ?? '' );
 					$meta         = (string) ( $item['meta'] ?? '' );
 					$cover_url    = (string) ( $item['coverUrl'] ?? '' );
+					$cover_format = child_get_media_cover_grid_cover_format( $item );
 					$type_label   = child_get_media_cover_grid_type_label( $type );
 					$source_title  = (string) ( $item['sourcePostTitle'] ?? '' );
 					$mention_count = max( 1, absint( $item['mentionCount'] ?? 1 ) );
@@ -86,7 +97,7 @@ return function( array $attributes ): string {
 					$tag_name = $link_url ? 'a' : 'div';
 					?>
 					<<?php echo tag_escape( $tag_name ); ?> class="child-media-cover-grid__item child-media-cover-grid__item--<?php echo esc_attr( $type ); ?>"<?php echo $link_url ? ' href="' . esc_url( $link_url ) . '"' . $link_target . $link_rel : ''; ?> role="listitem" aria-label="<?php echo esc_attr( $title ); ?>">
-						<div class="child-media-cover-grid__cover">
+						<div class="child-media-cover-grid__cover child-media-cover-grid__cover--<?php echo esc_attr( $cover_format ); ?>">
 							<?php if ( $cover_url ) : ?>
 								<img src="<?php echo esc_url( $cover_url ); ?>" alt="<?php echo esc_attr( $title ); ?>" loading="lazy" />
 							<?php else : ?>

--- a/blocks/media-cover-grid/render.php
+++ b/blocks/media-cover-grid/render.php
@@ -11,11 +11,8 @@ return function( array $attributes ): string {
 	}
 
 	$default_types     = [ 'book', 'movie', 'tv', 'game', 'music' ];
-	$default_formats   = [ 'portrait', 'square', 'landscape' ];
 	$media_types       = $attributes['mediaTypes'] ?? $default_types;
 	$allowed_types     = array_values( array_intersect( $default_types, is_array( $media_types ) ? $media_types : $default_types ) );
-	$cover_formats     = $attributes['coverFormats'] ?? $default_formats;
-	$allowed_formats   = array_values( array_intersect( $default_formats, is_array( $cover_formats ) ? $cover_formats : $default_formats ) );
 	$max_items         = max( 1, min( 120, absint( $attributes['maxItems'] ?? 48 ) ) );
 	$link_to           = in_array( $attributes['linkTo'] ?? 'post', [ 'post', 'external', 'none' ], true ) ? $attributes['linkTo'] : 'post';
 	$sort_order        = in_array( $attributes['sortOrder'] ?? 'newest', [ 'newest', 'oldest', 'title' ], true ) ? $attributes['sortOrder'] : 'newest';
@@ -24,15 +21,11 @@ return function( array $attributes ): string {
 	$show_type         = (bool) ( $attributes['showType'] ?? true );
 	$allow_duplicates  = (bool) ( $attributes['allowDuplicates'] ?? false );
 
-	if ( [] === $allowed_types || [] === $allowed_formats ) {
-		$empty_message = [] === $allowed_types
-			? esc_html__( 'Bitte wähle mindestens einen Medientyp aus.', 'child' )
-			: esc_html__( 'Bitte wähle mindestens ein Format aus.', 'child' );
-
+	if ( [] === $allowed_types ) {
 		return sprintf(
 			'<div %s><p class="child-media-cover-grid__empty">%s</p></div>',
 			get_block_wrapper_attributes( [ 'class' => 'child-media-cover-grid-block' ] ),
-			$empty_message
+			esc_html__( 'Bitte wähle mindestens einen Medientyp aus.', 'child' )
 		);
 	}
 
@@ -40,11 +33,8 @@ return function( array $attributes ): string {
 	$items = array_values(
 		array_filter(
 			$items,
-			static function( array $item ) use ( $allowed_types, $allowed_formats ): bool {
-				$type         = (string) ( $item['type'] ?? '' );
-				$cover_format = child_get_media_cover_grid_cover_format( $item );
-
-				return in_array( $type, $allowed_types, true ) && in_array( $cover_format, $allowed_formats, true );
+			static function( array $item ) use ( $allowed_types ): bool {
+				return in_array( $item['type'] ?? '', $allowed_types, true );
 			}
 		)
 	);
@@ -76,16 +66,6 @@ return function( array $attributes ): string {
 			)
 		)
 	);
-	$item_formats = array_values(
-		array_unique(
-			array_map(
-				static function( array $item ): string {
-					return child_get_media_cover_grid_cover_format( $item );
-				},
-				$items
-			)
-		)
-	);
 
 	ob_start();
 	?>
@@ -93,8 +73,8 @@ return function( array $attributes ): string {
 		<?php if ( [] === $items ) : ?>
 			<p class="child-media-cover-grid__empty"><?php echo esc_html__( 'Noch keine Medien gefunden.', 'child' ); ?></p>
 		<?php else : ?>
-			<div class="child-media-cover-grid__controls" aria-label="<?php echo esc_attr__( 'Medien filtern', 'child' ); ?>">
-				<?php if ( count( $item_types ) > 1 ) : ?>
+			<?php if ( count( $item_types ) > 1 ) : ?>
+				<div class="child-media-cover-grid__controls" aria-label="<?php echo esc_attr__( 'Medien filtern', 'child' ); ?>">
 					<div class="child-media-cover-grid__control-group" role="group" aria-label="<?php echo esc_attr__( 'Medientypen', 'child' ); ?>">
 						<span class="child-media-cover-grid__control-label"><?php echo esc_html__( 'Typ', 'child' ); ?></span>
 						<?php foreach ( $item_types as $item_type ) : ?>
@@ -103,19 +83,8 @@ return function( array $attributes ): string {
 							</button>
 						<?php endforeach; ?>
 					</div>
-				<?php endif; ?>
-
-				<?php if ( count( $item_formats ) > 1 ) : ?>
-					<div class="child-media-cover-grid__control-group" role="group" aria-label="<?php echo esc_attr__( 'Cover-Formate', 'child' ); ?>">
-						<span class="child-media-cover-grid__control-label"><?php echo esc_html__( 'Format', 'child' ); ?></span>
-						<?php foreach ( $item_formats as $item_format ) : ?>
-							<button class="child-media-cover-grid__filter is-active" type="button" data-child-media-filter-group="format" data-child-media-filter-value="<?php echo esc_attr( $item_format ); ?>" aria-pressed="true">
-								<?php echo esc_html( child_get_media_cover_grid_cover_format_label( $item_format ) ); ?>
-							</button>
-						<?php endforeach; ?>
-					</div>
-				<?php endif; ?>
-			</div>
+				</div>
+			<?php endif; ?>
 			<p class="child-media-cover-grid__empty child-media-cover-grid__empty--filtered" hidden><?php echo esc_html__( 'Keine Medien für diese Filter gefunden.', 'child' ); ?></p>
 			<div class="child-media-cover-grid" role="list">
 				<?php foreach ( $items as $item ) : ?>
@@ -142,7 +111,7 @@ return function( array $attributes ): string {
 
 					$tag_name = $link_url ? 'a' : 'div';
 					?>
-					<<?php echo tag_escape( $tag_name ); ?> class="child-media-cover-grid__item child-media-cover-grid__item--<?php echo esc_attr( $type ); ?>" data-child-media-type="<?php echo esc_attr( $type ); ?>" data-child-media-format="<?php echo esc_attr( $cover_format ); ?>"<?php echo $link_url ? ' href="' . esc_url( $link_url ) . '"' . $link_target . $link_rel : ''; ?> role="listitem" aria-label="<?php echo esc_attr( $title ); ?>">
+					<<?php echo tag_escape( $tag_name ); ?> class="child-media-cover-grid__item child-media-cover-grid__item--<?php echo esc_attr( $type ); ?>" data-child-media-type="<?php echo esc_attr( $type ); ?>"<?php echo $link_url ? ' href="' . esc_url( $link_url ) . '"' . $link_target . $link_rel : ''; ?> role="listitem" aria-label="<?php echo esc_attr( $title ); ?>">
 						<div class="child-media-cover-grid__cover child-media-cover-grid__cover--<?php echo esc_attr( $cover_format ); ?>">
 							<?php if ( $cover_url ) : ?>
 								<img src="<?php echo esc_url( $cover_url ); ?>" alt="<?php echo esc_attr( $title ); ?>" loading="lazy" />

--- a/blocks/media-cover-grid/style.css
+++ b/blocks/media-cover-grid/style.css
@@ -3,17 +3,70 @@
   margin-block: 1.5rem;
 }
 
+.child-media-cover-grid__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  margin-block-end: clamp(1rem, 2vw, 1.5rem);
+}
+
+.child-media-cover-grid__control-group {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.child-media-cover-grid__control-label {
+  color: color-mix(in srgb, currentColor 62%, transparent);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin-inline-end: 0.1rem;
+  text-transform: uppercase;
+}
+
+.child-media-cover-grid__filter {
+  background: color-mix(in srgb, currentColor 6%, transparent);
+  border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
+  border-radius: 999px;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 700;
+  line-height: 1.2;
+  padding: 0.45rem 0.75rem;
+}
+
+.child-media-cover-grid__filter:is(:hover, :focus-visible),
+.child-media-cover-grid__filter.is-active {
+  background: color-mix(in srgb, currentColor 14%, transparent);
+  border-color: color-mix(in srgb, currentColor 44%, transparent);
+}
+
+.child-media-cover-grid__filter:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--wp--preset--color--contrast, currentColor) 45%, transparent);
+  outline-offset: 2px;
+}
+
 .child-media-cover-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-  gap: clamp(1rem, 2vw, 1.5rem);
+  column-gap: clamp(1rem, 2vw, 1.5rem);
+  column-width: 150px;
 }
 
 .child-media-cover-grid__item {
+  break-inside: avoid;
   color: inherit;
-  display: block;
+  display: inline-block;
+  margin-block-end: clamp(1rem, 2vw, 1.5rem);
   min-width: 0;
   text-decoration: none;
+  width: 100%;
+}
+
+.child-media-cover-grid__item[hidden] {
+  display: none;
 }
 
 .child-media-cover-grid__item:is(a):hover .child-media-cover-grid__cover,
@@ -111,6 +164,7 @@
 
 @media (max-width: 600px) {
   .child-media-cover-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    column-count: 2;
+    column-width: auto;
   }
 }

--- a/blocks/media-cover-grid/style.css
+++ b/blocks/media-cover-grid/style.css
@@ -51,18 +51,20 @@
 }
 
 .child-media-cover-grid {
-  column-gap: clamp(1rem, 2vw, 1.5rem);
-  column-width: 150px;
+  --child-media-cover-grid-gap: clamp(1rem, 2vw, 1.5rem);
+  --child-media-cover-grid-row: 8px;
+  display: grid;
+  gap: var(--child-media-cover-grid-gap);
+  grid-auto-flow: row;
+  grid-auto-rows: var(--child-media-cover-grid-row);
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
 }
 
 .child-media-cover-grid__item {
-  break-inside: avoid;
   color: inherit;
-  display: inline-block;
-  margin-block-end: clamp(1rem, 2vw, 1.5rem);
+  display: block;
   min-width: 0;
   text-decoration: none;
-  width: 100%;
 }
 
 .child-media-cover-grid__item[hidden] {
@@ -164,7 +166,6 @@
 
 @media (max-width: 600px) {
   .child-media-cover-grid {
-    column-count: 2;
-    column-width: auto;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/blocks/media-cover-grid/style.css
+++ b/blocks/media-cover-grid/style.css
@@ -42,6 +42,19 @@
   width: 100%;
 }
 
+
+.child-media-cover-grid__cover--portrait {
+  aspect-ratio: 2 / 3;
+}
+
+.child-media-cover-grid__cover--square {
+  aspect-ratio: 1 / 1;
+}
+
+.child-media-cover-grid__cover--landscape {
+  aspect-ratio: 16 / 9;
+}
+
 .child-media-cover-grid__cover img {
   display: block;
   height: 100%;

--- a/blocks/media-cover-grid/style.css
+++ b/blocks/media-cover-grid/style.css
@@ -5,90 +5,137 @@
 
 .child-media-cover-grid__controls {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem 1.25rem;
-  margin-block-end: clamp(1rem, 2vw, 1.5rem);
+  justify-content: center;
+  margin-block-end: clamp(1.1rem, 2vw, 1.7rem);
 }
 
 .child-media-cover-grid__control-group {
   align-items: center;
-  display: flex;
+  background: color-mix(in srgb, #ffffff 88%, currentColor 12%);
+  border: 1px solid color-mix(in srgb, currentColor 10%, transparent);
+  border-radius: 999px;
+  box-shadow: 0 10px 28px color-mix(in srgb, currentColor 7%, transparent);
+  display: inline-flex;
   flex-wrap: wrap;
-  gap: 0.45rem;
+  gap: 0.2rem;
+  padding: 0.3rem;
 }
 
 .child-media-cover-grid__control-label {
   color: color-mix(in srgb, currentColor 62%, transparent);
-  font-size: 0.72rem;
+  font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.08em;
-  margin-inline-end: 0.1rem;
+  margin-inline-end: 0.35rem;
+  padding-inline-start: 0.65rem;
   text-transform: uppercase;
 }
 
 .child-media-cover-grid__filter {
-  background: color-mix(in srgb, currentColor 6%, transparent);
-  border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
+  background: transparent;
+  border: 0;
   border-radius: 999px;
-  color: inherit;
+  color: color-mix(in srgb, currentColor 82%, transparent);
   cursor: pointer;
   font: inherit;
   font-size: 0.82rem;
-  font-weight: 700;
+  font-weight: 600;
   line-height: 1.2;
-  padding: 0.45rem 0.75rem;
+  min-height: 2.3rem;
+  padding: 0.5rem 0.9rem;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
 }
 
-.child-media-cover-grid__filter:is(:hover, :focus-visible),
-.child-media-cover-grid__filter.is-active {
-  background: color-mix(in srgb, currentColor 14%, transparent);
-  border-color: color-mix(in srgb, currentColor 44%, transparent);
+.child-media-cover-grid__filter:not(.is-active) {
+  opacity: 1;
 }
 
 .child-media-cover-grid__filter:focus-visible {
-  outline: 3px solid color-mix(in srgb, var(--wp--preset--color--contrast, currentColor) 45%, transparent);
-  outline-offset: 2px;
+  outline: 2px solid color-mix(in srgb, var(--wp--preset--color--contrast, currentColor) 35%, transparent);
+  outline-offset: 1px;
+}
+
+.child-media-cover-grid__filter:hover {
+  background: color-mix(in srgb, currentColor 6%, transparent);
+}
+
+.child-media-cover-grid__filter.is-active {
+  background: #fff;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+  color: inherit;
 }
 
 .child-media-cover-grid {
-  --child-media-cover-grid-gap: clamp(1rem, 2vw, 1.5rem);
-  --child-media-cover-grid-row: 8px;
+  --child-media-cover-grid-gap: clamp(1.1rem, 1.8vw, 1.45rem);
+  align-items: start;
   display: grid;
   gap: var(--child-media-cover-grid-gap);
   grid-auto-flow: row;
-  grid-auto-rows: var(--child-media-cover-grid-row);
-  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  grid-auto-rows: auto;
+  grid-template-columns: repeat(auto-fill, minmax(165px, 1fr));
 }
 
 .child-media-cover-grid__item {
   color: inherit;
   display: block;
+  align-self: start;
   min-width: 0;
   text-decoration: none;
+}
+
+.child-media-cover-grid__year {
+  align-items: center;
+  color: color-mix(in srgb, currentColor 50%, transparent);
+  display: flex;
+  gap: 0.85rem;
+  grid-column: 1 / -1;
+  justify-content: center;
+  margin: 0.25rem 0 0.15rem;
+}
+
+.child-media-cover-grid__year::before,
+.child-media-cover-grid__year::after {
+  background: color-mix(in srgb, currentColor 12%, transparent);
+  border-radius: 999px;
+  content: '';
+  flex: 1;
+  height: 1px;
+}
+
+.child-media-cover-grid__year-label {
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
 }
 
 .child-media-cover-grid__item[hidden] {
   display: none;
 }
 
+.child-media-cover-grid__item--game {
+  grid-column: span 2;
+}
+
 .child-media-cover-grid__item:is(a):hover .child-media-cover-grid__cover,
 .child-media-cover-grid__item:is(a):focus-visible .child-media-cover-grid__cover {
-  box-shadow: 0 18px 35px color-mix(in srgb, currentColor 22%, transparent);
-  transform: translateY(-3px);
+  box-shadow: 0 16px 32px color-mix(in srgb, currentColor 16%, transparent);
+  transform: translateY(-1px);
 }
 
 .child-media-cover-grid__item:is(a):focus-visible {
-  border-radius: 14px;
-  outline: 3px solid color-mix(in srgb, var(--wp--preset--color--contrast, currentColor) 55%, transparent);
-  outline-offset: 5px;
+  border-radius: 18px;
+  outline: 2px solid color-mix(in srgb, var(--wp--preset--color--contrast, currentColor) 40%, transparent);
+  outline-offset: 4px;
 }
 
 .child-media-cover-grid__cover {
   align-items: center;
   aspect-ratio: 2 / 3;
   background: color-mix(in srgb, currentColor 8%, transparent);
-  border-radius: 14px;
-  box-shadow: 0 10px 25px color-mix(in srgb, currentColor 12%, transparent);
+  border-radius: 18px;
+  box-shadow: 0 12px 28px color-mix(in srgb, currentColor 10%, transparent);
   display: flex;
   justify-content: center;
   overflow: hidden;
@@ -108,6 +155,10 @@
 
 .child-media-cover-grid__cover--landscape {
   aspect-ratio: 16 / 9;
+}
+
+.child-media-cover-grid__item--game .child-media-cover-grid__cover--landscape {
+  aspect-ratio: 3 / 2.1;
 }
 
 .child-media-cover-grid__cover img {
@@ -131,23 +182,23 @@
 }
 
 .child-media-cover-grid__content {
-  padding-block-start: 0.7rem;
+  padding-block-start: 0.8rem;
 }
 
 .child-media-cover-grid__type {
   color: color-mix(in srgb, currentColor 64%, transparent);
   display: block;
-  font-size: 0.72rem;
+  font-size: 0.7rem;
   font-weight: 700;
   letter-spacing: 0.08em;
   line-height: 1.2;
-  margin-block-end: 0.25rem;
+  margin-block-end: 0.35rem;
   text-transform: uppercase;
 }
 
 .child-media-cover-grid__title {
-  font-size: clamp(0.95rem, 0.9rem + 0.2vw, 1.08rem);
-  line-height: 1.25;
+  font-size: clamp(0.98rem, 0.94rem + 0.18vw, 1.08rem);
+  line-height: 1.22;
   margin: 0;
 }
 
@@ -155,9 +206,9 @@
 .child-media-cover-grid__source,
 .child-media-cover-grid__empty {
   color: color-mix(in srgb, currentColor 68%, transparent);
-  font-size: 0.86rem;
-  line-height: 1.35;
-  margin: 0.25rem 0 0;
+  font-size: 0.82rem;
+  line-height: 1.4;
+  margin: 0.32rem 0 0;
 }
 
 .child-media-cover-grid__source {
@@ -165,7 +216,21 @@
 }
 
 @media (max-width: 600px) {
+  .child-media-cover-grid__control-group {
+    border-radius: 24px;
+  }
+
+  .child-media-cover-grid__control-label {
+    flex-basis: 100%;
+    margin-inline-end: 0;
+    padding: 0.3rem 0.45rem 0.1rem;
+  }
+
   .child-media-cover-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .child-media-cover-grid__year {
+    gap: 0.7rem;
   }
 }

--- a/blocks/media-cover-grid/view.js
+++ b/blocks/media-cover-grid/view.js
@@ -1,15 +1,8 @@
 const BLOCK_SELECTOR = '.wp-block-child-media-cover-grid, .child-media-cover-grid-block';
 const FILTER_SELECTOR = '[data-child-media-filter-group="type"]';
 const ITEM_SELECTOR = '[data-child-media-type]';
-
-const schedule = ( callback ) => {
-	if ( typeof window.requestAnimationFrame === 'function' ) {
-		window.requestAnimationFrame( callback );
-		return;
-	}
-
-	window.setTimeout( callback, 1 );
-};
+const YEAR_SELECTOR = '[data-child-media-year]';
+const ALL_FILTER_VALUE = 'all';
 
 const getActiveTypes = ( block ) => {
 	const buttons = Array.from( block.querySelectorAll( FILTER_SELECTOR ) );
@@ -18,33 +11,23 @@ const getActiveTypes = ( block ) => {
 		return null;
 	}
 
-	return new Set(
-		buttons
-			.filter( ( button ) => button.classList.contains( 'is-active' ) )
-			.map( ( button ) => button.dataset.childMediaFilterValue )
-	);
-};
+	const activeValues = buttons
+		.filter( ( button ) => button.classList.contains( 'is-active' ) )
+		.map( ( button ) => button.dataset.childMediaFilterValue );
 
-const layoutMasonryGrid = ( block ) => {
-	const grid = block.querySelector( '.child-media-cover-grid' );
-	if ( ! grid ) {
-		return;
+	if ( activeValues.length === 0 || activeValues.includes( ALL_FILTER_VALUE ) ) {
+		return null;
 	}
 
-	const styles = window.getComputedStyle( grid );
-	const rowSize = Number.parseFloat( styles.getPropertyValue( 'grid-auto-rows' ) ) || 8;
-	const rowGap = Number.parseFloat( styles.getPropertyValue( 'row-gap' ) ) || 0;
+	return new Set( activeValues );
+};
 
-	grid.querySelectorAll( ITEM_SELECTOR ).forEach( ( item ) => {
-		item.style.gridRowEnd = '';
+const syncFilterButtons = ( block, activeValues ) => {
+	block.querySelectorAll( FILTER_SELECTOR ).forEach( ( button ) => {
+		const isActive = activeValues.has( button.dataset.childMediaFilterValue );
 
-		if ( item.hidden ) {
-			return;
-		}
-
-		const itemHeight = item.getBoundingClientRect().height;
-		const rowSpan = Math.max( 1, Math.ceil( ( itemHeight + rowGap ) / ( rowSize + rowGap ) ) );
-		item.style.gridRowEnd = `span ${ rowSpan }`;
+		button.classList.toggle( 'is-active', isActive );
+		button.setAttribute( 'aria-pressed', isActive ? 'true' : 'false' );
 	} );
 };
 
@@ -68,7 +51,37 @@ const updateGrid = ( block ) => {
 		emptyMessage.hidden = visibleItems > 0;
 	}
 
-	schedule( () => layoutMasonryGrid( block ) );
+	const grid = block.querySelector( '.child-media-cover-grid' );
+	if ( ! grid ) {
+		return;
+	}
+
+	let currentYear = null;
+	let currentYearHasVisibleItems = false;
+
+	const flushYearVisibility = () => {
+		if ( ! currentYear ) {
+			return;
+		}
+
+		currentYear.hidden = ! currentYearHasVisibleItems;
+		currentYear.setAttribute( 'aria-hidden', currentYearHasVisibleItems ? 'false' : 'true' );
+	};
+
+	Array.from( grid.children ).forEach( ( child ) => {
+		if ( child.matches( YEAR_SELECTOR ) ) {
+			flushYearVisibility();
+			currentYear = child;
+			currentYearHasVisibleItems = false;
+			return;
+		}
+
+		if ( child.matches( ITEM_SELECTOR ) && ! child.hidden ) {
+			currentYearHasVisibleItems = true;
+		}
+	} );
+
+	flushYearVisibility();
 };
 
 const initFilterButton = ( block, button ) => {
@@ -79,10 +92,33 @@ const initFilterButton = ( block, button ) => {
 	button.dataset.childMediaFilterInitialized = '1';
 
 	button.addEventListener( 'click', () => {
-		const isActive = ! button.classList.contains( 'is-active' );
+		const value = button.dataset.childMediaFilterValue;
+		const buttons = Array.from( block.querySelectorAll( FILTER_SELECTOR ) );
+		const activeValues = new Set(
+			buttons
+				.filter( ( currentButton ) => currentButton.classList.contains( 'is-active' ) )
+				.map( ( currentButton ) => currentButton.dataset.childMediaFilterValue )
+		);
 
-		button.classList.toggle( 'is-active', isActive );
-		button.setAttribute( 'aria-pressed', isActive ? 'true' : 'false' );
+		if ( value === ALL_FILTER_VALUE ) {
+			syncFilterButtons( block, new Set( [ ALL_FILTER_VALUE ] ) );
+			updateGrid( block );
+			return;
+		}
+
+		activeValues.delete( ALL_FILTER_VALUE );
+
+		if ( activeValues.has( value ) ) {
+			activeValues.delete( value );
+		} else {
+			activeValues.add( value );
+		}
+
+		if ( activeValues.size === 0 ) {
+			activeValues.add( ALL_FILTER_VALUE );
+		}
+
+		syncFilterButtons( block, activeValues );
 		updateGrid( block );
 	} );
 };
@@ -94,14 +130,7 @@ const initMediaCoverGrid = ( block ) => {
 
 	block.dataset.childMediaCoverGridInitialized = '1';
 	block.querySelectorAll( FILTER_SELECTOR ).forEach( ( button ) => initFilterButton( block, button ) );
-
-	block.querySelectorAll( '.child-media-cover-grid__cover img' ).forEach( ( image ) => {
-		if ( image.complete ) {
-			return;
-		}
-
-		image.addEventListener( 'load', () => schedule( () => layoutMasonryGrid( block ) ), { once: true } );
-	} );
+	syncFilterButtons( block, new Set( [ ALL_FILTER_VALUE ] ) );
 
 	updateGrid( block );
 };
@@ -115,9 +144,3 @@ if ( document.readyState === 'loading' ) {
 } else {
 	initializeMediaCoverGrids();
 }
-
-window.addEventListener( 'resize', () => {
-	schedule( () => {
-		document.querySelectorAll( BLOCK_SELECTOR ).forEach( layoutMasonryGrid );
-	} );
-} );

--- a/blocks/media-cover-grid/view.js
+++ b/blocks/media-cover-grid/view.js
@@ -1,20 +1,18 @@
 const BLOCK_SELECTOR = '.wp-block-child-media-cover-grid, .child-media-cover-grid-block';
-const FILTER_SELECTOR = '[data-child-media-filter-group]';
-const ITEM_SELECTOR = '[data-child-media-type][data-child-media-format]';
+const FILTER_SELECTOR = '[data-child-media-filter-group="type"]';
+const ITEM_SELECTOR = '[data-child-media-type]';
 
 const schedule = ( callback ) => {
-	if ( typeof window.requestIdleCallback === 'function' ) {
-		window.requestIdleCallback( callback, { timeout: 900 } );
+	if ( typeof window.requestAnimationFrame === 'function' ) {
+		window.requestAnimationFrame( callback );
 		return;
 	}
 
 	window.setTimeout( callback, 1 );
 };
 
-const getActiveValues = ( block, group ) => {
-	const buttons = Array.from(
-		block.querySelectorAll( `${ FILTER_SELECTOR }[data-child-media-filter-group="${ group }"]` )
-	);
+const getActiveTypes = ( block ) => {
+	const buttons = Array.from( block.querySelectorAll( FILTER_SELECTOR ) );
 
 	if ( buttons.length === 0 ) {
 		return null;
@@ -27,15 +25,35 @@ const getActiveValues = ( block, group ) => {
 	);
 };
 
+const layoutMasonryGrid = ( block ) => {
+	const grid = block.querySelector( '.child-media-cover-grid' );
+	if ( ! grid ) {
+		return;
+	}
+
+	const styles = window.getComputedStyle( grid );
+	const rowSize = Number.parseFloat( styles.getPropertyValue( 'grid-auto-rows' ) ) || 8;
+	const rowGap = Number.parseFloat( styles.getPropertyValue( 'row-gap' ) ) || 0;
+
+	grid.querySelectorAll( ITEM_SELECTOR ).forEach( ( item ) => {
+		item.style.gridRowEnd = '';
+
+		if ( item.hidden ) {
+			return;
+		}
+
+		const itemHeight = item.getBoundingClientRect().height;
+		const rowSpan = Math.max( 1, Math.ceil( ( itemHeight + rowGap ) / ( rowSize + rowGap ) ) );
+		item.style.gridRowEnd = `span ${ rowSpan }`;
+	} );
+};
+
 const updateGrid = ( block ) => {
-	const activeTypes = getActiveValues( block, 'type' );
-	const activeFormats = getActiveValues( block, 'format' );
+	const activeTypes = getActiveTypes( block );
 	let visibleItems = 0;
 
 	block.querySelectorAll( ITEM_SELECTOR ).forEach( ( item ) => {
-		const typeMatches = activeTypes === null || activeTypes.has( item.dataset.childMediaType );
-		const formatMatches = activeFormats === null || activeFormats.has( item.dataset.childMediaFormat );
-		const isVisible = typeMatches && formatMatches;
+		const isVisible = activeTypes === null || activeTypes.has( item.dataset.childMediaType );
 
 		item.hidden = ! isVisible;
 		item.setAttribute( 'aria-hidden', isVisible ? 'false' : 'true' );
@@ -49,6 +67,8 @@ const updateGrid = ( block ) => {
 	if ( emptyMessage ) {
 		emptyMessage.hidden = visibleItems > 0;
 	}
+
+	schedule( () => layoutMasonryGrid( block ) );
 };
 
 const initFilterButton = ( block, button ) => {
@@ -74,6 +94,15 @@ const initMediaCoverGrid = ( block ) => {
 
 	block.dataset.childMediaCoverGridInitialized = '1';
 	block.querySelectorAll( FILTER_SELECTOR ).forEach( ( button ) => initFilterButton( block, button ) );
+
+	block.querySelectorAll( '.child-media-cover-grid__cover img' ).forEach( ( image ) => {
+		if ( image.complete ) {
+			return;
+		}
+
+		image.addEventListener( 'load', () => schedule( () => layoutMasonryGrid( block ) ), { once: true } );
+	} );
+
 	updateGrid( block );
 };
 
@@ -82,7 +111,13 @@ const initializeMediaCoverGrids = () => {
 };
 
 if ( document.readyState === 'loading' ) {
-	document.addEventListener( 'DOMContentLoaded', () => schedule( initializeMediaCoverGrids ), { once: true } );
+	document.addEventListener( 'DOMContentLoaded', initializeMediaCoverGrids, { once: true } );
 } else {
-	schedule( initializeMediaCoverGrids );
+	initializeMediaCoverGrids();
 }
+
+window.addEventListener( 'resize', () => {
+	schedule( () => {
+		document.querySelectorAll( BLOCK_SELECTOR ).forEach( layoutMasonryGrid );
+	} );
+} );

--- a/blocks/media-cover-grid/view.js
+++ b/blocks/media-cover-grid/view.js
@@ -1,0 +1,88 @@
+const BLOCK_SELECTOR = '.wp-block-child-media-cover-grid, .child-media-cover-grid-block';
+const FILTER_SELECTOR = '[data-child-media-filter-group]';
+const ITEM_SELECTOR = '[data-child-media-type][data-child-media-format]';
+
+const schedule = ( callback ) => {
+	if ( typeof window.requestIdleCallback === 'function' ) {
+		window.requestIdleCallback( callback, { timeout: 900 } );
+		return;
+	}
+
+	window.setTimeout( callback, 1 );
+};
+
+const getActiveValues = ( block, group ) => {
+	const buttons = Array.from(
+		block.querySelectorAll( `${ FILTER_SELECTOR }[data-child-media-filter-group="${ group }"]` )
+	);
+
+	if ( buttons.length === 0 ) {
+		return null;
+	}
+
+	return new Set(
+		buttons
+			.filter( ( button ) => button.classList.contains( 'is-active' ) )
+			.map( ( button ) => button.dataset.childMediaFilterValue )
+	);
+};
+
+const updateGrid = ( block ) => {
+	const activeTypes = getActiveValues( block, 'type' );
+	const activeFormats = getActiveValues( block, 'format' );
+	let visibleItems = 0;
+
+	block.querySelectorAll( ITEM_SELECTOR ).forEach( ( item ) => {
+		const typeMatches = activeTypes === null || activeTypes.has( item.dataset.childMediaType );
+		const formatMatches = activeFormats === null || activeFormats.has( item.dataset.childMediaFormat );
+		const isVisible = typeMatches && formatMatches;
+
+		item.hidden = ! isVisible;
+		item.setAttribute( 'aria-hidden', isVisible ? 'false' : 'true' );
+
+		if ( isVisible ) {
+			visibleItems += 1;
+		}
+	} );
+
+	const emptyMessage = block.querySelector( '.child-media-cover-grid__empty--filtered' );
+	if ( emptyMessage ) {
+		emptyMessage.hidden = visibleItems > 0;
+	}
+};
+
+const initFilterButton = ( block, button ) => {
+	if ( button.dataset.childMediaFilterInitialized === '1' ) {
+		return;
+	}
+
+	button.dataset.childMediaFilterInitialized = '1';
+
+	button.addEventListener( 'click', () => {
+		const isActive = ! button.classList.contains( 'is-active' );
+
+		button.classList.toggle( 'is-active', isActive );
+		button.setAttribute( 'aria-pressed', isActive ? 'true' : 'false' );
+		updateGrid( block );
+	} );
+};
+
+const initMediaCoverGrid = ( block ) => {
+	if ( ! block || block.dataset.childMediaCoverGridInitialized === '1' ) {
+		return;
+	}
+
+	block.dataset.childMediaCoverGridInitialized = '1';
+	block.querySelectorAll( FILTER_SELECTOR ).forEach( ( button ) => initFilterButton( block, button ) );
+	updateGrid( block );
+};
+
+const initializeMediaCoverGrids = () => {
+	document.querySelectorAll( BLOCK_SELECTOR ).forEach( initMediaCoverGrid );
+};
+
+if ( document.readyState === 'loading' ) {
+	document.addEventListener( 'DOMContentLoaded', () => schedule( initializeMediaCoverGrids ), { once: true } );
+} else {
+	schedule( initializeMediaCoverGrids );
+}

--- a/blocks/media-recommendation/components/MediaPreview.js
+++ b/blocks/media-recommendation/components/MediaPreview.js
@@ -1,0 +1,54 @@
+import { __ } from '@wordpress/i18n';
+
+export const MediaPreview = ( { mediaTitle, mediaType, posterUrl, releaseYear, serviceUrl } ) => {
+	if ( ! mediaTitle?.trim() ) {
+		return (
+			<div className="media-preview--empty">
+				{ __( 'Bitte wähle einen Film oder eine Serie aus der Suche aus.', 'child' ) }
+			</div>
+		);
+	}
+
+	const posterLink = serviceUrl?.trim();
+
+	return (
+		<div className="child-media-card" aria-label={ mediaType === 'movie' ? __( 'Film', 'child' ) : __( 'Serie', 'child' ) }>
+			<div className="child-media-card__media">
+				{ posterUrl ? (
+					posterLink ? (
+						<a
+							className="child-media-card__poster-link"
+							href={ posterLink }
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							<img
+								className="child-media-card__poster"
+								src={ posterUrl }
+								alt={ mediaTitle }
+								loading="lazy"
+							/>
+						</a>
+					) : (
+						<img
+							className="child-media-card__poster"
+							src={ posterUrl }
+							alt={ mediaTitle }
+							loading="lazy"
+						/>
+					)
+				) : (
+					<div className="child-media-card__placeholder" aria-hidden="true" />
+				) }
+			</div>
+			<div className="child-media-card__meta">
+				<h3 className="child-media-card__title">{ mediaTitle }</h3>
+				{ releaseYear?.trim() ? (
+					<p className="child-media-card__year">
+						{ releaseYear }
+					</p>
+				) : null }
+			</div>
+		</div>
+	);
+};

--- a/blocks/media-recommendation/components/SearchResults.js
+++ b/blocks/media-recommendation/components/SearchResults.js
@@ -1,0 +1,39 @@
+import { __ } from '@wordpress/i18n';
+import { SearchResultsList } from '../../shared/media/SearchResultsList';
+
+export const SearchResults = ( { results, selectedId, onSelect } ) => (
+	<SearchResultsList
+		results={ results }
+		selectedId={ selectedId }
+		onSelect={ onSelect }
+		className="media-search-results"
+		getId={ ( media ) => media.id }
+		getClassName={ ( media, isSelected ) => `media-search-result${ isSelected ? ' is-active' : '' }` }
+	>
+		{ ( media ) => (
+			<>
+				{ media.poster ? (
+					<span className="media-search-result__thumb">
+						<img src={ media.poster } alt={ media.title || '' } loading="lazy" />
+					</span>
+				) : (
+					<span
+						className="media-search-result__thumb media-search-result__thumb--placeholder"
+						aria-hidden="true"
+					>
+						🎬
+					</span>
+				) }
+				<span className="media-search-result__details">
+					<span className="media-search-result__title">{ media.title }</span>
+					{ media.year ? (
+						<span className="media-search-result__year">{ media.year }</span>
+					) : null }
+					<span className="media-search-result__type">
+						{ media.mediaType === 'movie' ? __( 'Film', 'child' ) : __( 'Serie', 'child' ) }
+					</span>
+				</span>
+			</>
+		) }
+	</SearchResultsList>
+);

--- a/blocks/media-recommendation/editor.css
+++ b/blocks/media-recommendation/editor.css
@@ -73,6 +73,41 @@
     font-style: italic;
 }
 
+.wp-block-child-media-recommendation .media-search-results {
+    max-width: 100%;
+}
+
+.wp-block-child-media-recommendation .components-button.media-search-result {
+    display: grid !important;
+    grid-template-columns: 44px minmax(0, 1fr);
+    align-items: center;
+    width: 100%;
+    max-width: 100%;
+    min-height: 82px;
+    overflow: hidden;
+    white-space: normal;
+}
+
+.wp-block-child-media-recommendation .media-search-result__thumb,
+.wp-block-child-media-recommendation .media-search-result__thumb img {
+    width: 44px !important;
+    height: 64px !important;
+    max-width: 44px !important;
+    max-height: 64px !important;
+}
+
+.wp-block-child-media-recommendation .media-search-result__details {
+    min-width: 0;
+    overflow: hidden;
+}
+
+.wp-block-child-media-recommendation .media-search-result__title,
+.wp-block-child-media-recommendation .media-search-result__year,
+.wp-block-child-media-recommendation .media-search-result__type {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .media-preview--empty {
     margin-top: 1.5rem;
     padding: 2rem;

--- a/blocks/media-recommendation/hooks/useMediaSearch.js
+++ b/blocks/media-recommendation/hooks/useMediaSearch.js
@@ -1,0 +1,54 @@
+import { __ } from '@wordpress/i18n';
+import { useSearchState } from '../../shared/media/useSearchState';
+import { mapTmdbResults } from '../utils';
+
+export const useMediaSearch = () => {
+	const search = useSearchState();
+
+	const searchMedia = async () => {
+		const trimmedTerm = search.searchTerm.trim();
+
+		if ( ! trimmedTerm ) {
+			search.failSearch( __( 'Bitte gib einen Suchbegriff ein.', 'child' ) );
+			return;
+		}
+
+		search.beginSearch();
+
+		try {
+			const ajaxUrl = window.childMediaSearch?.ajaxUrl || '/wp-admin/admin-ajax.php';
+			const nonce = window.childMediaSearch?.nonce || '';
+			const response = await fetch(
+				`${ ajaxUrl }?action=child_tmdb_search&query=${ encodeURIComponent( trimmedTerm ) }&nonce=${ nonce }`
+			);
+
+			if ( ! response.ok ) {
+				throw new Error( 'Request failed' );
+			}
+
+			const data = await response.json();
+
+			if ( ! data.success ) {
+				throw new Error( data.data || 'Request failed' );
+			}
+
+			search.completeSearch( mapTmdbResults( data.data ), __( 'Keine Ergebnisse gefunden.', 'child' ) );
+		} catch ( error ) {
+			console.error( 'Fehler beim Suchen:', error );
+			search.failSearch(
+				error.message || __( 'Beim Suchen ist ein Fehler aufgetreten. Bitte versuche es erneut.', 'child' )
+			);
+		} finally {
+			search.finishSearch();
+		}
+	};
+
+	const selectMedia = ( media ) => search.selectResult( media );
+
+	return {
+		...search,
+		selectedMediaId: search.selectedId,
+		searchMedia,
+		selectMedia,
+	};
+};

--- a/blocks/media-recommendation/index.js
+++ b/blocks/media-recommendation/index.js
@@ -1,302 +1,142 @@
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, TextControl, Button, Spinner, Notice, SelectControl } from '@wordpress/components';
-import { useState, useEffect } from '@wordpress/element';
+import { PanelBody, TextControl, Button, SelectControl } from '@wordpress/components';
+import { useEffect } from '@wordpress/element';
 import metadata from './block.json';
+import { MediaPreview } from './components/MediaPreview';
+import { SearchResults } from './components/SearchResults';
+import { useMediaSearch } from './hooks/useMediaSearch';
+import { SearchFeedback } from '../shared/media/SearchFeedback';
 import './editor.css';
 import './style.css';
 
-const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p/w500';
+function Edit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps();
+	const { mediaTitle, mediaType, posterUrl, releaseYear, serviceUrl } = attributes;
+	const {
+		searchTerm,
+		setSearchTerm,
+		isSearching,
+		searchResults,
+		selectedMediaId,
+		searchError,
+		hasSearched,
+		searchMedia,
+		selectMedia,
+	} = useMediaSearch();
 
-const normalizePosterUrl = (path) => {
-    if (!path) {
-        return '';
-    }
-    if (path.startsWith('http')) {
-        return path;
-    }
-    return `${TMDB_IMAGE_BASE}${path}`;
-};
+	useEffect( () => {
+		if ( ! mediaTitle ) {
+			return;
+		}
 
-const MediaPreview = ({ mediaTitle, mediaType, posterUrl, releaseYear, serviceUrl }) => {
-    if (!mediaTitle?.trim()) {
-        return (
-            <div className="media-preview--empty">
-                {__('Bitte wähle einen Film oder eine Serie aus der Suche aus.', 'child')}
-            </div>
-        );
-    }
+		setSearchTerm( ( currentValue ) => ( currentValue ? currentValue : mediaTitle ) );
+	}, [ mediaTitle, setSearchTerm ] );
 
-    const posterLink = serviceUrl?.trim();
+	const handleMediaSelection = ( media ) => {
+		selectMedia( media );
+		setAttributes( {
+			mediaTitle: media.title || mediaTitle,
+			mediaType: media.mediaType,
+			posterUrl: media.poster || posterUrl || '',
+			releaseYear: media.year || releaseYear || '',
+			tmdbId: media.tmdbId || 0,
+			serviceUrl: media.serviceUrl || serviceUrl || '',
+		} );
+	};
 
-    return (
-        <div className="child-media-card" aria-label={mediaType === 'movie' ? __('Film', 'child') : __('Serie', 'child')}>
-            <div className="child-media-card__media">
-                {posterUrl ? (
-                    posterLink ? (
-                        <a
-                            className="child-media-card__poster-link"
-                            href={posterLink}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            <img
-                                className="child-media-card__poster"
-                                src={posterUrl}
-                                alt={mediaTitle}
-                                loading="lazy"
-                            />
-                        </a>
-                    ) : (
-                        <img
-                            className="child-media-card__poster"
-                            src={posterUrl}
-                            alt={mediaTitle}
-                            loading="lazy"
-                        />
-                    )
-                ) : (
-                    <div className="child-media-card__placeholder" aria-hidden="true" />
-                )}
-            </div>
-            <div className="child-media-card__meta">
-                <h3 className="child-media-card__title">{mediaTitle}</h3>
-                {releaseYear?.trim() ? (
-                    <p className="child-media-card__year">
-                        {releaseYear}
-                    </p>
-                ) : null}
-            </div>
-        </div>
-    );
-};
+	const handleSearchKeyDown = ( event ) => {
+		if ( event.key === 'Enter' ) {
+			event.preventDefault();
+			searchMedia();
+		}
+	};
 
-const SearchResults = ({ results, selectedId, onSelect }) => {
-    if (!results.length) {
-        return null;
-    }
+	return (
+		<div { ...blockProps }>
+			<InspectorControls>
+				<PanelBody title={ __( 'Film/Serie suchen', 'child' ) } initialOpen={ true }>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Suche nach Titel', 'child' ) }
+						value={ searchTerm }
+						onChange={ setSearchTerm }
+						placeholder={ __( 'Titel eingeben...', 'child' ) }
+						onKeyDown={ handleSearchKeyDown }
+					/>
+					<Button
+						variant="primary"
+						onClick={ searchMedia }
+						disabled={ isSearching }
+						className="media-search-button"
+					>
+						{ isSearching ? __( 'Suche...', 'child' ) : __( 'Suchen', 'child' ) }
+					</Button>
+					<SearchFeedback
+						isSearching={ isSearching }
+						error={ searchError }
+						loadingClassName="media-search-loading"
+					/>
+					{ ! isSearching && hasSearched && (
+						<SearchResults
+							results={ searchResults }
+							selectedId={ selectedMediaId }
+							onSelect={ handleMediaSelection }
+						/>
+					) }
+				</PanelBody>
 
-    return (
-        <div className="media-search-results">
-            {results.map((media) => (
-                <Button
-                    key={media.id}
-                    variant={media.id === selectedId ? 'primary' : 'secondary'}
-                    onClick={() => onSelect(media)}
-                    className={`media-search-result${media.id === selectedId ? ' is-active' : ''}`}
-                >
-                    {media.poster ? (
-                        <span className="media-search-result__thumb">
-                            <img src={media.poster} alt={media.title || ''} loading="lazy" />
-                        </span>
-                    ) : (
-                        <span
-                            className="media-search-result__thumb media-search-result__thumb--placeholder"
-                            aria-hidden="true"
-                        >
-                            🎬
-                        </span>
-                    )}
-                    <span className="media-search-result__details">
-                        <span className="media-search-result__title">{media.title}</span>
-                        {media.year ? (
-                            <span className="media-search-result__year">{media.year}</span>
-                        ) : null}
-                        <span className="media-search-result__type">
-                            {media.mediaType === 'movie' ? __('Film', 'child') : __('Serie', 'child')}
-                        </span>
-                    </span>
-                </Button>
-            ))}
-        </div>
-    );
-};
+				<PanelBody title={ __( 'Details', 'child' ) } initialOpen={ true }>
+					<SelectControl
+						label={ __( 'Typ', 'child' ) }
+						value={ mediaType }
+						options={ [
+							{ label: __( 'Film', 'child' ), value: 'movie' },
+							{ label: __( 'Serie', 'child' ), value: 'tv' },
+						] }
+						onChange={ ( value ) => setAttributes( { mediaType: value } ) }
+					/>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Titel', 'child' ) }
+						value={ mediaTitle }
+						onChange={ ( value ) => setAttributes( { mediaTitle: value } ) }
+					/>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Jahr', 'child' ) }
+						value={ releaseYear }
+						onChange={ ( value ) => setAttributes( { releaseYear: value } ) }
+					/>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Poster-URL', 'child' ) }
+						value={ posterUrl }
+						onChange={ ( value ) => setAttributes( { posterUrl: value } ) }
+						help={ __( 'Optional: Eigenes Poster einfügen', 'child' ) }
+					/>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Streaming-Link', 'child' ) }
+						value={ serviceUrl }
+						onChange={ ( value ) => setAttributes( { serviceUrl: value } ) }
+						help={ __( 'Wird bei der Suche automatisch befüllt (TMDB-Link), kann aber manuell überschrieben werden.', 'child' ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
 
-function Edit({ attributes, setAttributes }) {
-    const blockProps = useBlockProps();
-    const { mediaTitle, mediaType, posterUrl, releaseYear, tmdbId, serviceUrl } = attributes;
-    const [searchTerm, setSearchTerm] = useState('');
-    const [isSearching, setIsSearching] = useState(false);
-    const [searchResults, setSearchResults] = useState([]);
-    const [selectedMediaId, setSelectedMediaId] = useState(null);
-    const [searchError, setSearchError] = useState('');
-    const [hasSearched, setHasSearched] = useState(false);
-
-    useEffect(() => {
-        if (!mediaTitle) {
-            return;
-        }
-
-        setSearchTerm((currentValue) => (currentValue ? currentValue : mediaTitle));
-    }, [mediaTitle]);
-
-    const searchMedia = async () => {
-        const trimmedTerm = searchTerm.trim();
-        if (!trimmedTerm) {
-            setSearchError(__('Bitte gib einen Suchbegriff ein.', 'child'));
-            setHasSearched(false);
-            return;
-        }
-
-        setIsSearching(true);
-        setSearchError('');
-        setSearchResults([]);
-        setSelectedMediaId(null);
-        
-        try {
-            // Use WordPress AJAX endpoint for server-side API calls
-            const ajaxUrl = window.childMediaSearch?.ajaxUrl || '/wp-admin/admin-ajax.php';
-            const nonce = window.childMediaSearch?.nonce || '';
-            
-            const response = await fetch(
-                `${ajaxUrl}?action=child_tmdb_search&query=${encodeURIComponent(trimmedTerm)}&nonce=${nonce}`
-            );
-
-            if (!response.ok) {
-                throw new Error('Request failed');
-            }
-
-            const data = await response.json();
-            
-            if (!data.success) {
-                throw new Error(data.data || 'Request failed');
-            }
-
-            const { movies = [], tv = [] } = data.data;
-
-            const movieResults = (movies || []).slice(0, 3).map((item) => ({
-                id: `movie-${item.id}`,
-                tmdbId: item.id,
-                title: item.title || '',
-                year: item.release_date ? new Date(item.release_date).getFullYear().toString() : '',
-                poster: normalizePosterUrl(item.poster_path),
-                mediaType: 'movie',
-                serviceUrl: item.id ? `https://www.themoviedb.org/movie/${item.id}` : ''
-            }));
-
-            const tvResults = (tv || []).slice(0, 3).map((item) => ({
-                id: `tv-${item.id}`,
-                tmdbId: item.id,
-                title: item.name || '',
-                year: item.first_air_date ? new Date(item.first_air_date).getFullYear().toString() : '',
-                poster: normalizePosterUrl(item.poster_path),
-                mediaType: 'tv',
-                serviceUrl: item.id ? `https://www.themoviedb.org/tv/${item.id}` : ''
-            }));
-
-            const results = [...movieResults, ...tvResults];
-            setSearchResults(results);
-            setHasSearched(true);
-            
-            if (!results.length) {
-                setSearchError(__('Keine Ergebnisse gefunden.', 'child'));
-            }
-        } catch (error) {
-            console.error('Fehler beim Suchen:', error);
-            setSearchError(error.message || __('Beim Suchen ist ein Fehler aufgetreten. Bitte versuche es erneut.', 'child'));
-            setHasSearched(false);
-        }
-        setIsSearching(false);
-    };
-
-    const handleMediaSelection = (media) => {
-        setSelectedMediaId(media.id);
-        setSearchTerm(media.title);
-        setAttributes({
-            mediaTitle: media.title || mediaTitle,
-            mediaType: media.mediaType,
-            posterUrl: media.poster || posterUrl || '',
-            releaseYear: media.year || releaseYear || '',
-            tmdbId: media.tmdbId || 0,
-            serviceUrl: media.serviceUrl || serviceUrl || ''
-        });
-    };
-
-    return (
-        <div {...blockProps}>
-            <InspectorControls>
-                <PanelBody title={__('Film/Serie suchen', 'child')} initialOpen={true}>
-                    <TextControl __next40pxDefaultSize __nextHasNoMarginBottom
-                        label={__('Suche nach Titel', 'child')}
-                        value={searchTerm}
-                        onChange={setSearchTerm}
-                        placeholder={__('Titel eingeben...', 'child')}
-                        onKeyDown={(event) => {
-                            if (event.key === 'Enter') {
-                                event.preventDefault();
-                                searchMedia();
-                            }
-                        }}
-                    />
-                    <Button
-                        variant="primary"
-                        onClick={searchMedia}
-                        disabled={isSearching}
-                        className="media-search-button"
-                    >
-                        {isSearching ? __('Suche...', 'child') : __('Suchen', 'child')}
-                    </Button>
-                    {isSearching && (
-                        <div className="media-search-loading">
-                            <Spinner />
-                        </div>
-                    )}
-                    {searchError && (
-                        <Notice status="error" isDismissible={false}>
-                            {searchError}
-                        </Notice>
-                    )}
-                    {!isSearching && hasSearched && (
-                        <SearchResults
-                            results={searchResults}
-                            selectedId={selectedMediaId}
-                            onSelect={handleMediaSelection}
-                        />
-                    )}
-                </PanelBody>
-
-                <PanelBody title={__('Details', 'child')} initialOpen={true}>
-                    <SelectControl
-                        label={__('Typ', 'child')}
-                        value={mediaType}
-                        options={[
-                            { label: __('Film', 'child'), value: 'movie' },
-                            { label: __('Serie', 'child'), value: 'tv' }
-                        ]}
-                        onChange={(value) => setAttributes({ mediaType: value })}
-                    />
-                    <TextControl __next40pxDefaultSize __nextHasNoMarginBottom
-                        label={__('Titel', 'child')}
-                        value={mediaTitle}
-                        onChange={(value) => setAttributes({ mediaTitle: value })}
-                    />
-                    <TextControl __next40pxDefaultSize __nextHasNoMarginBottom
-                        label={__('Jahr', 'child')}
-                        value={releaseYear}
-                        onChange={(value) => setAttributes({ releaseYear: value })}
-                    />
-                    <TextControl __next40pxDefaultSize __nextHasNoMarginBottom
-                        label={__('Poster-URL', 'child')}
-                        value={posterUrl}
-                        onChange={(value) => setAttributes({ posterUrl: value })}
-                        help={__('Optional: Eigenes Poster einfügen', 'child')}
-                    />
-                    <TextControl __next40pxDefaultSize __nextHasNoMarginBottom
-                        label={__('Streaming-Link', 'child')}
-                        value={serviceUrl}
-                        onChange={(value) => setAttributes({ serviceUrl: value })}
-                        help={__('Wird bei der Suche automatisch befüllt (TMDB-Link), kann aber manuell überschrieben werden.', 'child')}
-                    />
-                </PanelBody>
-            </InspectorControls>
-
-            <MediaPreview {...attributes} />
-        </div>
-    );
+			<MediaPreview { ...attributes } />
+		</div>
+	);
 }
 
-registerBlockType(metadata.name, {
-    edit: Edit,
-    save: () => null
-});
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/blocks/media-recommendation/utils.js
+++ b/blocks/media-recommendation/utils.js
@@ -1,0 +1,37 @@
+const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p/w500';
+
+export const normalizePosterUrl = ( path ) => {
+	if ( ! path ) {
+		return '';
+	}
+
+	if ( path.startsWith( 'http' ) ) {
+		return path;
+	}
+
+	return `${ TMDB_IMAGE_BASE }${ path }`;
+};
+
+export const mapTmdbResults = ( { movies = [], tv = [] } = {} ) => {
+	const movieResults = ( movies || [] ).slice( 0, 3 ).map( ( item ) => ( {
+		id: `movie-${ item.id }`,
+		tmdbId: item.id,
+		title: item.title || '',
+		year: item.release_date ? new Date( item.release_date ).getFullYear().toString() : '',
+		poster: normalizePosterUrl( item.poster_path ),
+		mediaType: 'movie',
+		serviceUrl: item.id ? `https://www.themoviedb.org/movie/${ item.id }` : '',
+	} ) );
+
+	const tvResults = ( tv || [] ).slice( 0, 3 ).map( ( item ) => ( {
+		id: `tv-${ item.id }`,
+		tmdbId: item.id,
+		title: item.name || '',
+		year: item.first_air_date ? new Date( item.first_air_date ).getFullYear().toString() : '',
+		poster: normalizePosterUrl( item.poster_path ),
+		mediaType: 'tv',
+		serviceUrl: item.id ? `https://www.themoviedb.org/tv/${ item.id }` : '',
+	} ) );
+
+	return [ ...movieResults, ...tvResults ];
+};

--- a/blocks/music-recommendation/components/MusicPreview.js
+++ b/blocks/music-recommendation/components/MusicPreview.js
@@ -1,0 +1,32 @@
+import { __ } from '@wordpress/i18n';
+
+export const MusicPreview = ( { attributes } ) => {
+	const { musicType, title, artist, albumTitle, releaseYear, coverUrl } = attributes;
+
+	if ( ! title?.trim() ) {
+		return <div className="music-preview--empty">{ __( 'Suche einen Song oder ein Album aus.', 'child' ) }</div>;
+	}
+
+	const typeLabel = musicType === 'album' ? __( 'Album', 'child' ) : __( 'Song', 'child' );
+
+	return (
+		<div className="child-music-card" aria-label={ typeLabel }>
+			<div className="child-music-card__media">
+				{ coverUrl ? (
+					<img className="child-music-card__cover" src={ coverUrl } alt={ title } loading="lazy" />
+				) : (
+					<div className="child-music-card__placeholder" aria-hidden="true">♪</div>
+				) }
+			</div>
+			<div className="child-music-card__meta">
+				<span className="child-music-card__type">{ typeLabel }</span>
+				<h3 className="child-music-card__title">{ title }</h3>
+				{ artist ? <p className="child-music-card__artist">{ artist }</p> : null }
+				{ musicType === 'song' && albumTitle && albumTitle !== title ? (
+					<p className="child-music-card__album">{ albumTitle }</p>
+				) : null }
+				{ releaseYear ? <p className="child-music-card__year">{ releaseYear }</p> : null }
+			</div>
+		</div>
+	);
+};

--- a/blocks/music-recommendation/components/SearchResults.js
+++ b/blocks/music-recommendation/components/SearchResults.js
@@ -1,0 +1,28 @@
+import { SearchResultsList } from '../../shared/media/SearchResultsList';
+
+export const SearchResults = ( { results, onSelect, selectedId } ) => (
+	<SearchResultsList
+		results={ results }
+		selectedId={ selectedId }
+		onSelect={ onSelect }
+		className="music-search-results"
+		getKey={ ( item ) => `${ item.musicType }-${ item.id }` }
+		getId={ ( item ) => item.id }
+		getClassName={ ( item, isSelected ) => `music-search-result${ isSelected ? ' is-active' : '' }` }
+	>
+		{ ( item ) => (
+			<>
+				{ item.coverUrl ? (
+					<span className="music-search-result__thumb"><img src={ item.coverUrl } alt="" loading="lazy" /></span>
+				) : (
+					<span className="music-search-result__thumb music-search-result__thumb--placeholder" aria-hidden="true">♪</span>
+				) }
+				<span className="music-search-result__details">
+					<span className="music-search-result__title">{ item.title }</span>
+					{ item.artist ? <span className="music-search-result__artist">{ item.artist }</span> : null }
+					{ item.releaseYear ? <span className="music-search-result__year">{ item.releaseYear }</span> : null }
+				</span>
+			</>
+		) }
+	</SearchResultsList>
+);

--- a/blocks/music-recommendation/hooks/useMusicSearch.js
+++ b/blocks/music-recommendation/hooks/useMusicSearch.js
@@ -1,0 +1,44 @@
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import { useSearchState } from '../../shared/media/useSearchState';
+
+export const useMusicSearch = ( { initialTerm = '', initialSelectedId = '' } = {} ) => {
+	const search = useSearchState( { initialTerm, initialSelectedId } );
+
+	const searchMusic = async ( musicType ) => {
+		if ( ! search.searchTerm.trim() ) {
+			search.failSearch( __( 'Bitte gib einen Suchbegriff ein.', 'child' ) );
+			return;
+		}
+
+		search.beginSearch( { clearResults: false, clearSelected: false } );
+
+		try {
+			const response = await apiFetch( {
+				path: addQueryArgs( '/child/v1/music', {
+					q: search.searchTerm,
+					musicType,
+				} ),
+			} );
+			const found = response?.results || [];
+
+			search.completeSearch( found, __( 'Keine Musik gefunden.', 'child' ) );
+		} catch ( fetchError ) {
+			search.failSearch( fetchError?.message || __( 'Die Musiksuche konnte nicht geladen werden.', 'child' ) );
+		} finally {
+			search.finishSearch();
+		}
+	};
+
+	const selectMusic = ( item ) => search.selectResult( item );
+
+	return {
+		...search,
+		results: search.searchResults,
+		error: search.searchError,
+		selectedId: search.selectedId,
+		searchMusic,
+		selectMusic,
+	};
+};

--- a/blocks/music-recommendation/index.js
+++ b/blocks/music-recommendation/index.js
@@ -1,202 +1,129 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, SelectControl, TextControl, Button, Spinner, Notice } from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
-import apiFetch from '@wordpress/api-fetch';
-import { addQueryArgs } from '@wordpress/url';
+import { PanelBody, SelectControl, TextControl, Button, Notice } from '@wordpress/components';
+import { useEffect } from '@wordpress/element';
 import metadata from './block.json';
+import { MusicPreview } from './components/MusicPreview';
+import { SearchResults } from './components/SearchResults';
+import { useMusicSearch } from './hooks/useMusicSearch';
+import { SearchFeedback } from '../shared/media/SearchFeedback';
 import './editor.css';
 import './style.css';
 
-const MusicPreview = ({ attributes }) => {
-    const { musicType, title, artist, albumTitle, releaseYear, coverUrl, provider, providerUrl, previewUrl } = attributes;
+function Edit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps();
+	const { musicType, title, artist, albumTitle, releaseYear, coverUrl, providerUrl, previewUrl } = attributes;
+	const {
+		searchTerm,
+		setSearchTerm,
+		results,
+		isSearching,
+		error,
+		selectedId,
+		searchMusic,
+		selectMusic,
+		resetResults,
+	} = useMusicSearch( {
+		initialTerm: title || '',
+		initialSelectedId: attributes.providerId || '',
+	} );
 
-    if (!title?.trim()) {
-        return <div className="music-preview--empty">{__('Suche einen Song oder ein Album aus.', 'child')}</div>;
-    }
+	useEffect( () => {
+		if ( ! searchTerm && title ) {
+			setSearchTerm( title );
+		}
+	}, [ title, searchTerm, setSearchTerm ] );
 
-    const typeLabel = musicType === 'album' ? __('Album', 'child') : __('Song', 'child');
+	const updateMusicType = ( value ) => {
+		setAttributes( { musicType: value, previewUrl: value === 'album' ? '' : previewUrl } );
+		resetResults();
+	};
 
-    return (
-        <div className="child-music-card" aria-label={typeLabel}>
-            <div className="child-music-card__media">
-                {coverUrl ? (
-                    <img className="child-music-card__cover" src={coverUrl} alt={title} loading="lazy" />
-                ) : (
-                    <div className="child-music-card__placeholder" aria-hidden="true">♪</div>
-                )}
-            </div>
-            <div className="child-music-card__meta">
-                <span className="child-music-card__type">{typeLabel}</span>
-                <h3 className="child-music-card__title">{title}</h3>
-                {artist ? <p className="child-music-card__artist">{artist}</p> : null}
-                {musicType === 'song' && albumTitle && albumTitle !== title ? (
-                    <p className="child-music-card__album">{albumTitle}</p>
-                ) : null}
-                {releaseYear ? <p className="child-music-card__year">{releaseYear}</p> : null}
-            </div>
-        </div>
-    );
-};
+	const handleMusicSearch = () => {
+		searchMusic( musicType );
+	};
 
-const SearchResults = ({ results, onSelect, selectedId }) => {
-    if (!results.length) {
-        return null;
-    }
+	const handleMusicSelection = ( item ) => {
+		selectMusic( item );
+		setAttributes( {
+			musicType: item.musicType || musicType,
+			title: item.title || title,
+			artist: item.artist || artist,
+			albumTitle: item.albumTitle || albumTitle,
+			releaseYear: item.releaseYear || releaseYear,
+			coverUrl: item.coverUrl || coverUrl,
+			provider: item.provider || 'Apple/iTunes',
+			providerId: item.id || '',
+			providerUrl: item.providerUrl || providerUrl,
+			previewUrl: item.previewUrl || '',
+		} );
+	};
 
-    return (
-        <div className="music-search-results">
-            {results.map((item) => (
-                <Button
-                    key={`${item.musicType}-${item.id}`}
-                    variant={item.id === selectedId ? 'primary' : 'secondary'}
-                    onClick={() => onSelect(item)}
-                    className={`music-search-result${item.id === selectedId ? ' is-active' : ''}`}
-                >
-                    {item.coverUrl ? (
-                        <span className="music-search-result__thumb"><img src={item.coverUrl} alt="" loading="lazy" /></span>
-                    ) : (
-                        <span className="music-search-result__thumb music-search-result__thumb--placeholder" aria-hidden="true">♪</span>
-                    )}
-                    <span className="music-search-result__details">
-                        <span className="music-search-result__title">{item.title}</span>
-                        {item.artist ? <span className="music-search-result__artist">{item.artist}</span> : null}
-                        {item.releaseYear ? <span className="music-search-result__year">{item.releaseYear}</span> : null}
-                    </span>
-                </Button>
-            ))}
-        </div>
-    );
-};
+	const handleSearchKeyDown = ( event ) => {
+		if ( event.key === 'Enter' ) {
+			event.preventDefault();
+			handleMusicSearch();
+		}
+	};
 
-registerBlockType(metadata.name, {
-    ...metadata,
-    edit: ({ attributes, setAttributes }) => {
-        const blockProps = useBlockProps();
-        const { musicType, title, artist, albumTitle, releaseYear, coverUrl, providerUrl, previewUrl } = attributes;
-        const [searchTerm, setSearchTerm] = useState(title || '');
-        const [results, setResults] = useState([]);
-        const [isSearching, setIsSearching] = useState(false);
-        const [error, setError] = useState('');
-        const [selectedId, setSelectedId] = useState(attributes.providerId || '');
+	return (
+		<div { ...blockProps }>
+			<InspectorControls>
+				<PanelBody title={ __( 'Musik-Einstellungen', 'child' ) } initialOpen>
+					<SelectControl
+						label={ __( 'Typ', 'child' ) }
+						value={ musicType }
+						options={ [
+							{ label: __( 'Song', 'child' ), value: 'song' },
+							{ label: __( 'Album', 'child' ), value: 'album' },
+						] }
+						onChange={ updateMusicType }
+					/>
+					<TextControl label={ __( 'Titel', 'child' ) } value={ title } onChange={ ( value ) => setAttributes( { title: value } ) } />
+					<TextControl label={ __( 'Künstler:in', 'child' ) } value={ artist } onChange={ ( value ) => setAttributes( { artist: value } ) } />
+					<TextControl label={ __( 'Album', 'child' ) } value={ albumTitle } onChange={ ( value ) => setAttributes( { albumTitle: value } ) } />
+					<TextControl label={ __( 'Jahr', 'child' ) } value={ releaseYear } onChange={ ( value ) => setAttributes( { releaseYear: value } ) } />
+					<TextControl label={ __( 'Cover-URL', 'child' ) } value={ coverUrl } onChange={ ( value ) => setAttributes( { coverUrl: value } ) } />
+					<TextControl label={ __( 'Anbieter-Link', 'child' ) } value={ providerUrl } onChange={ ( value ) => setAttributes( { providerUrl: value } ) } />
+					<TextControl label={ __( 'Hörprobe-URL', 'child' ) } value={ previewUrl } onChange={ ( value ) => setAttributes( { previewUrl: value } ) } help={ __( 'Nur rechtmäßig bereitgestellte Preview-URLs verwenden; keine vollständigen Songs ohne Lizenz einbinden.', 'child' ) } />
+				</PanelBody>
+				<PanelBody title={ __( 'Recht & Datenschutz', 'child' ) } initialOpen={ false }>
+					<Notice status="info" isDismissible={ false }>
+						{ __( 'Der Block nutzt Anbieter-Metadaten als Empfehlung/Promotion. Hörproben werden im Frontend erst nach Klick geladen, damit keine externe Audio-Verbindung ohne Aktion der Leser:innen aufgebaut wird.', 'child' ) }
+					</Notice>
+				</PanelBody>
+			</InspectorControls>
 
-        useEffect(() => {
-            if (!searchTerm && title) {
-                setSearchTerm(title);
-            }
-        }, [title]);
+			<div className="music-search-panel">
+				<SelectControl
+					label={ __( 'Was möchtest du empfehlen?', 'child' ) }
+					value={ musicType }
+					options={ [
+						{ label: __( 'Song', 'child' ), value: 'song' },
+						{ label: __( 'Album', 'child' ), value: 'album' },
+					] }
+					onChange={ updateMusicType }
+				/>
+				<TextControl
+					label={ __( 'Musik suchen', 'child' ) }
+					value={ searchTerm }
+					onChange={ setSearchTerm }
+					onKeyDown={ handleSearchKeyDown }
+				/>
+				<Button variant="primary" onClick={ handleMusicSearch } disabled={ isSearching } className="music-search-button">
+					{ isSearching ? __( 'Suche…', 'child' ) : __( 'Suchen', 'child' ) }
+				</Button>
+				<SearchFeedback isSearching={ isSearching } error={ error } errorStatus="warning" />
+				<SearchResults results={ results } onSelect={ handleMusicSelection } selectedId={ selectedId } />
+			</div>
 
-        const searchMusic = async () => {
-            if (!searchTerm.trim()) {
-                setError(__('Bitte gib einen Suchbegriff ein.', 'child'));
-                return;
-            }
+			<MusicPreview attributes={ attributes } />
+		</div>
+	);
+}
 
-            setIsSearching(true);
-            setError('');
-
-            try {
-                const response = await apiFetch({
-                    path: addQueryArgs('/child/v1/music', {
-                        q: searchTerm,
-                        musicType,
-                    }),
-                });
-                const found = response?.results || [];
-                setResults(found);
-                if (!found.length) {
-                    setError(__('Keine Musik gefunden.', 'child'));
-                }
-            } catch (fetchError) {
-                setError(fetchError?.message || __('Die Musiksuche konnte nicht geladen werden.', 'child'));
-            } finally {
-                setIsSearching(false);
-            }
-        };
-
-        const selectMusic = (item) => {
-            setSelectedId(item.id);
-            setSearchTerm(item.title);
-            setAttributes({
-                musicType: item.musicType || musicType,
-                title: item.title || title,
-                artist: item.artist || artist,
-                albumTitle: item.albumTitle || albumTitle,
-                releaseYear: item.releaseYear || releaseYear,
-                coverUrl: item.coverUrl || coverUrl,
-                provider: item.provider || 'Apple/iTunes',
-                providerId: item.id || '',
-                providerUrl: item.providerUrl || providerUrl,
-                previewUrl: item.previewUrl || '',
-            });
-        };
-
-        return (
-            <div {...blockProps}>
-                <InspectorControls>
-                    <PanelBody title={__('Musik-Einstellungen', 'child')} initialOpen>
-                        <SelectControl
-                            label={__('Typ', 'child')}
-                            value={musicType}
-                            options={[
-                                { label: __('Song', 'child'), value: 'song' },
-                                { label: __('Album', 'child'), value: 'album' },
-                            ]}
-                            onChange={(value) => {
-                                setAttributes({ musicType: value, previewUrl: value === 'album' ? '' : previewUrl });
-                                setResults([]);
-                            }}
-                        />
-                        <TextControl label={__('Titel', 'child')} value={title} onChange={(value) => setAttributes({ title: value })} />
-                        <TextControl label={__('Künstler:in', 'child')} value={artist} onChange={(value) => setAttributes({ artist: value })} />
-                        <TextControl label={__('Album', 'child')} value={albumTitle} onChange={(value) => setAttributes({ albumTitle: value })} />
-                        <TextControl label={__('Jahr', 'child')} value={releaseYear} onChange={(value) => setAttributes({ releaseYear: value })} />
-                        <TextControl label={__('Cover-URL', 'child')} value={coverUrl} onChange={(value) => setAttributes({ coverUrl: value })} />
-                        <TextControl label={__('Anbieter-Link', 'child')} value={providerUrl} onChange={(value) => setAttributes({ providerUrl: value })} />
-                        <TextControl label={__('Hörprobe-URL', 'child')} value={previewUrl} onChange={(value) => setAttributes({ previewUrl: value })} help={__('Nur rechtmäßig bereitgestellte Preview-URLs verwenden; keine vollständigen Songs ohne Lizenz einbinden.', 'child')} />
-                    </PanelBody>
-                    <PanelBody title={__('Recht & Datenschutz', 'child')} initialOpen={false}>
-                        <Notice status="info" isDismissible={false}>
-                            {__('Der Block nutzt Anbieter-Metadaten als Empfehlung/Promotion. Hörproben werden im Frontend erst nach Klick geladen, damit keine externe Audio-Verbindung ohne Aktion der Leser:innen aufgebaut wird.', 'child')}
-                        </Notice>
-                    </PanelBody>
-                </InspectorControls>
-
-                <div className="music-search-panel">
-                    <SelectControl
-                        label={__('Was möchtest du empfehlen?', 'child')}
-                        value={musicType}
-                        options={[
-                            { label: __('Song', 'child'), value: 'song' },
-                            { label: __('Album', 'child'), value: 'album' },
-                        ]}
-                        onChange={(value) => {
-                            setAttributes({ musicType: value, previewUrl: value === 'album' ? '' : previewUrl });
-                            setResults([]);
-                        }}
-                    />
-                    <TextControl
-                        label={__('Musik suchen', 'child')}
-                        value={searchTerm}
-                        onChange={setSearchTerm}
-                        onKeyDown={(event) => {
-                            if (event.key === 'Enter') {
-                                event.preventDefault();
-                                searchMusic();
-                            }
-                        }}
-                    />
-                    <Button variant="primary" onClick={searchMusic} disabled={isSearching} className="music-search-button">
-                        {isSearching ? __('Suche…', 'child') : __('Suchen', 'child')}
-                    </Button>
-                    {isSearching ? <Spinner /> : null}
-                    {error ? <Notice status="warning" isDismissible={false}>{error}</Notice> : null}
-                    <SearchResults results={results} onSelect={selectMusic} selectedId={selectedId} />
-                </div>
-
-                <MusicPreview attributes={attributes} />
-            </div>
-        );
-    },
-});
+registerBlockType( metadata.name, {
+	...metadata,
+	edit: Edit,
+} );

--- a/blocks/shared/media/SearchFeedback.js
+++ b/blocks/shared/media/SearchFeedback.js
@@ -1,0 +1,17 @@
+import { Notice, Spinner } from '@wordpress/components';
+
+export const SearchFeedback = ( { isSearching, error, loadingClassName = '', errorStatus = 'error' } ) => (
+	<>
+		{ isSearching && loadingClassName ? (
+			<div className={ loadingClassName }>
+				<Spinner />
+			</div>
+		) : null }
+		{ isSearching && ! loadingClassName ? <Spinner /> : null }
+		{ error ? (
+			<Notice status={ errorStatus } isDismissible={ false }>
+				{ error }
+			</Notice>
+		) : null }
+	</>
+);

--- a/blocks/shared/media/SearchResultsList.js
+++ b/blocks/shared/media/SearchResultsList.js
@@ -1,0 +1,27 @@
+import { Button } from '@wordpress/components';
+
+export const SearchResultsList = ( { results, selectedId, onSelect, className, getKey, getId, getClassName, children } ) => {
+	if ( ! results.length ) {
+		return null;
+	}
+
+	return (
+		<div className={ className }>
+			{ results.map( ( result ) => {
+				const id = getId( result );
+				const isSelected = id === selectedId;
+
+				return (
+					<Button
+						key={ getKey ? getKey( result ) : id }
+						variant={ isSelected ? 'primary' : 'secondary' }
+						onClick={ () => onSelect( result ) }
+						className={ getClassName( result, isSelected ) }
+					>
+						{ children( result, isSelected ) }
+					</Button>
+				);
+			} ) }
+		</div>
+	);
+};

--- a/blocks/shared/media/useSearchState.js
+++ b/blocks/shared/media/useSearchState.js
@@ -1,0 +1,71 @@
+import { useState } from '@wordpress/element';
+
+export const useSearchState = ( { initialTerm = '', initialSelectedId = null } = {} ) => {
+	const [ searchTerm, setSearchTerm ] = useState( initialTerm );
+	const [ isSearching, setIsSearching ] = useState( false );
+	const [ searchResults, setSearchResults ] = useState( [] );
+	const [ selectedId, setSelectedId ] = useState( initialSelectedId );
+	const [ searchError, setSearchError ] = useState( '' );
+	const [ hasSearched, setHasSearched ] = useState( false );
+
+	const beginSearch = ( { clearResults = true, clearSelected = true } = {} ) => {
+		setIsSearching( true );
+		setSearchError( '' );
+
+		if ( clearResults ) {
+			setSearchResults( [] );
+		}
+
+		if ( clearSelected ) {
+			setSelectedId( null );
+		}
+	};
+
+	const completeSearch = ( results, emptyMessage = '' ) => {
+		setSearchResults( results );
+		setHasSearched( true );
+
+		if ( ! results.length && emptyMessage ) {
+			setSearchError( emptyMessage );
+		}
+	};
+
+	const failSearch = ( message ) => {
+		setSearchError( message );
+		setHasSearched( false );
+	};
+
+	const finishSearch = () => {
+		setIsSearching( false );
+	};
+
+	const selectResult = ( result, { getId = ( item ) => item.id, getTitle = ( item ) => item.title } = {} ) => {
+		setSelectedId( getId( result ) );
+		setSearchTerm( getTitle( result ) || '' );
+		return result;
+	};
+
+	const resetResults = () => {
+		setSearchResults( [] );
+		setHasSearched( false );
+		setSearchError( '' );
+	};
+
+	return {
+		searchTerm,
+		setSearchTerm,
+		isSearching,
+		searchResults,
+		selectedId,
+		setSelectedId,
+		searchError,
+		setSearchError,
+		hasSearched,
+		beginSearch,
+		completeSearch,
+		failSearch,
+		finishSearch,
+		selectResult,
+		resetResults,
+	};
+};

--- a/blocks/videogame-recommendation/editor.css
+++ b/blocks/videogame-recommendation/editor.css
@@ -75,6 +75,40 @@
 	color: #50575e;
 }
 
+.wp-block-child-videogame-recommendation .game-search-results {
+	max-width: 100%;
+}
+
+.wp-block-child-videogame-recommendation .components-button.game-search-result {
+	display: grid !important;
+	grid-template-columns: 80px minmax(0, 1fr);
+	align-items: center;
+	width: 100%;
+	max-width: 100%;
+	min-height: 64px;
+	overflow: hidden;
+	white-space: normal;
+}
+
+.wp-block-child-videogame-recommendation .game-search-result__thumb,
+.wp-block-child-videogame-recommendation .game-search-result__thumb img {
+	width: 80px !important;
+	height: 45px !important;
+	max-width: 80px !important;
+	max-height: 45px !important;
+}
+
+.wp-block-child-videogame-recommendation .game-search-result__details {
+	min-width: 0;
+	overflow: hidden;
+}
+
+.wp-block-child-videogame-recommendation .game-search-result__title,
+.wp-block-child-videogame-recommendation .game-search-result__year {
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
 /* Empty State */
 .game-preview--empty {
 	margin-top: 1.5rem;

--- a/blocks/videogame-recommendation/hooks/useGameSearch.js
+++ b/blocks/videogame-recommendation/hooks/useGameSearch.js
@@ -1,31 +1,22 @@
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useSearchState } from '../../shared/media/useSearchState';
 import { transformGameData } from '../utils';
 
 /**
  * Custom hook for game search functionality
  */
 export const useGameSearch = () => {
-	const [searchTerm, setSearchTerm] = useState('');
-	const [isSearching, setIsSearching] = useState(false);
-	const [searchResults, setSearchResults] = useState([]);
-	const [selectedGameId, setSelectedGameId] = useState(null);
-	const [searchError, setSearchError] = useState('');
-	const [hasSearched, setHasSearched] = useState(false);
+	const search = useSearchState();
 
 	const searchGames = async () => {
-		const trimmedTerm = searchTerm.trim();
+		const trimmedTerm = search.searchTerm.trim();
 		
 		if (!trimmedTerm) {
-			setSearchError(__('Bitte gib einen Suchbegriff ein.', 'child'));
-			setHasSearched(false);
+			search.failSearch(__('Bitte gib einen Suchbegriff ein.', 'child'));
 			return;
 		}
 
-		setIsSearching(true);
-		setSearchError('');
-		setSearchResults([]);
-		setSelectedGameId(null);
+		search.beginSearch();
 		
 		try {
 			const ajaxUrl = window.childGameSearch?.ajaxUrl || '/wp-admin/admin-ajax.php';
@@ -48,38 +39,30 @@ export const useGameSearch = () => {
 			const { games = [] } = data.data;
 			const gameResults = games.slice(0, 6).map(transformGameData);
 
-			setSearchResults(gameResults);
-			setHasSearched(true);
-			
-			if (!gameResults.length) {
-				setSearchError(__('Keine Ergebnisse gefunden.', 'child'));
-			}
+			search.completeSearch(gameResults, __('Keine Ergebnisse gefunden.', 'child'));
 		} catch (error) {
 			console.error('Fehler beim Suchen:', error);
-			setSearchError(
+			search.failSearch(
 				error.message || 
 				__('Beim Suchen ist ein Fehler aufgetreten. Bitte versuche es erneut.', 'child')
 			);
-			setHasSearched(false);
 		} finally {
-			setIsSearching(false);
+			search.finishSearch();
 		}
 	};
 
 	const selectGame = (game) => {
-		setSelectedGameId(game.id);
-		setSearchTerm(game.title);
-		return game;
+		return search.selectResult(game);
 	};
 
 	return {
-		searchTerm,
-		setSearchTerm,
-		isSearching,
-		searchResults,
-		selectedGameId,
-		searchError,
-		hasSearched,
+		searchTerm: search.searchTerm,
+		setSearchTerm: search.setSearchTerm,
+		isSearching: search.isSearching,
+		searchResults: search.searchResults,
+		selectedGameId: search.selectedId,
+		searchError: search.searchError,
+		hasSearched: search.hasSearched,
 		searchGames,
 		selectGame
 	};

--- a/blocks/videogame-recommendation/render.php
+++ b/blocks/videogame-recommendation/render.php
@@ -7,40 +7,10 @@
  */
 
 return function( $attributes ) {
-	/**
-	 * Get platform display info from platform name
-	 * @param string $platform_name - Raw platform name from API
-	 * @return array - ['name' => string, 'color' => string]
-	 */
-	$get_platform_info = function( $platform_name ) {
-		$name = strtolower( $platform_name );
-		
-		$platforms = [
-			['match' => ['playstation 5', 'ps5'], 'name' => 'PS5', 'color' => '#003087'],
-			['match' => ['playstation 4', 'ps4'], 'name' => 'PS4', 'color' => '#003087'],
-			['match' => ['playstation'], 'name' => 'PlayStation', 'color' => '#003087'],
-			['match' => ['xbox series'], 'name' => 'Xbox Series', 'color' => '#107C10'],
-			['match' => ['xbox one'], 'name' => 'Xbox One', 'color' => '#107C10'],
-			['match' => ['xbox'], 'name' => 'Xbox', 'color' => '#107C10'],
-			['match' => ['nintendo switch', 'switch'], 'name' => 'Switch', 'color' => '#E60012'],
-			['match' => ['nintendo'], 'name' => 'Nintendo', 'color' => '#E60012'],
-			['match' => ['pc', 'windows'], 'name' => 'PC', 'color' => '#0078D4'],
-			['match' => ['ios', 'iphone'], 'name' => 'iOS', 'color' => '#555555'],
-			['match' => ['android'], 'name' => 'Android', 'color' => '#3DDC84'],
-			['match' => ['linux'], 'name' => 'Linux', 'color' => '#FCC624'],
-			['match' => ['mac'], 'name' => 'macOS', 'color' => '#999999']
-		];
-		
-		foreach ( $platforms as $platform ) {
-			foreach ( $platform['match'] as $match ) {
-				if ( strpos( $name, $match ) !== false ) {
-					return ['name' => $platform['name'], 'color' => $platform['color']];
-				}
-			}
-		}
-		
-		return ['name' => $platform_name, 'color' => '#666666'];
-	};
+	$utils_file = __DIR__ . '/utils.php';
+	if ( is_readable( $utils_file ) ) {
+		require_once $utils_file;
+	}
 	
 	$wrapper_attributes = get_block_wrapper_attributes();
 	$game_title = $attributes['gameTitle'] ?? '';
@@ -94,7 +64,9 @@ return function( $attributes ) {
 				<?php if ( ! empty( $platforms ) && is_array( $platforms ) ) : ?>
 					<div class="child-game-card__platforms" aria-label="<?php echo esc_attr( __( 'Plattformen', 'child' ) ); ?>">
 						<?php foreach ( array_slice( $platforms, 0, 5 ) as $platform ) : 
-							$platform_info = $get_platform_info( $platform );
+							$platform_info = function_exists( 'child_get_platform_info' )
+								? child_get_platform_info( $platform )
+								: [ 'name' => $platform, 'color' => '#666666' ];
 						?>
 							<span 
 								class="child-game-card__platform-chip" 

--- a/blocks/videogame-recommendation/utils.php
+++ b/blocks/videogame-recommendation/utils.php
@@ -1,6 +1,9 @@
+<?php
 /**
  * Platform utilities for PHP render
  * Shared platform configuration between JS and PHP
+ *
+ * @package TwentyTwentyFiveChild
  */
 
 /**
@@ -8,6 +11,7 @@
  * @param string $platform_name - Raw platform name from API
  * @return array - ['name' => string, 'color' => string]
  */
+if ( ! function_exists( 'child_get_platform_info' ) ) {
 function child_get_platform_info( $platform_name ) {
 	$name = strtolower( $platform_name );
 	
@@ -36,4 +40,5 @@ function child_get_platform_info( $platform_name ) {
 	}
 	
 	return ['name' => $platform_name, 'color' => '#666666'];
+}
 }

--- a/inc/media-cover-grid-normalizers.php
+++ b/inc/media-cover-grid-normalizers.php
@@ -71,6 +71,7 @@ function child_normalize_media_cover_grid_book_block( array $attrs ): ?array {
 		'title'       => $title,
 		'meta'        => trim( (string) ( $attrs['author'] ?? '' ) ),
 		'coverUrl'    => esc_url_raw( (string) ( $attrs['coverUrl'] ?? '' ) ),
+		'coverFormat' => 'portrait',
 		'externalUrl' => esc_url_raw( (string) ( $attrs['shopUrl'] ?? '' ) ),
 	];
 }
@@ -94,6 +95,7 @@ function child_normalize_media_cover_grid_media_recommendation_block( array $att
 		'title'       => $title,
 		'meta'        => trim( (string) ( $attrs['releaseYear'] ?? '' ) ),
 		'coverUrl'    => esc_url_raw( (string) ( $attrs['posterUrl'] ?? '' ) ),
+		'coverFormat' => 'portrait',
 		'externalUrl' => esc_url_raw( (string) ( $attrs['serviceUrl'] ?? '' ) ),
 		'tmdbId'      => absint( $attrs['tmdbId'] ?? 0 ),
 	];
@@ -125,6 +127,7 @@ function child_normalize_media_cover_grid_videogame_block( array $attrs ): ?arra
 		'title'       => $title,
 		'meta'        => implode( ' · ', $meta_parts ),
 		'coverUrl'    => esc_url_raw( (string) ( $attrs['coverUrl'] ?? '' ) ),
+		'coverFormat' => 'landscape',
 		'externalUrl' => esc_url_raw( (string) ( $attrs['shopUrl'] ?? '' ) ),
 		'rawgId'      => absint( $attrs['rawgId'] ?? 0 ),
 	];
@@ -153,6 +156,7 @@ function child_normalize_media_cover_grid_music_block( array $attrs ): ?array {
 		'title'       => $title,
 		'meta'        => implode( ' · ', $meta_parts ),
 		'coverUrl'    => esc_url_raw( (string) ( $attrs['coverUrl'] ?? '' ) ),
+		'coverFormat' => 'square',
 		'externalUrl' => esc_url_raw( (string) ( $attrs['providerUrl'] ?? '' ) ),
 		'providerId'  => sanitize_text_field( (string) ( $attrs['providerId'] ?? '' ) ),
 	];

--- a/inc/media-cover-grid-normalizers.php
+++ b/inc/media-cover-grid-normalizers.php
@@ -55,6 +55,43 @@ function child_normalize_media_cover_grid_block( array $block, WP_Post $post ): 
 }
 
 /**
+ * Build a normalized media-cover-grid item from common fields.
+ *
+ * @param array<string, mixed> $args Media item fields.
+ * @return array<string, mixed>
+ */
+function child_create_media_cover_grid_item( array $args ): array {
+	$item = [
+		'type'        => sanitize_key( (string) ( $args['type'] ?? '' ) ),
+		'title'       => trim( (string) ( $args['title'] ?? '' ) ),
+		'meta'        => trim( (string) ( $args['meta'] ?? '' ) ),
+		'coverUrl'    => esc_url_raw( (string) ( $args['coverUrl'] ?? '' ) ),
+		'coverFormat' => sanitize_key( (string) ( $args['coverFormat'] ?? 'portrait' ) ),
+		'externalUrl' => esc_url_raw( (string) ( $args['externalUrl'] ?? '' ) ),
+	];
+
+	foreach ( $args as $key => $value ) {
+		if ( array_key_exists( $key, $item ) ) {
+			continue;
+		}
+
+		$item[ $key ] = $value;
+	}
+
+	return $item;
+}
+
+/**
+ * Join visible media metadata parts with the shared separator.
+ *
+ * @param array<int, string> $parts Metadata parts.
+ * @return string
+ */
+function child_join_media_cover_grid_meta( array $parts ): string {
+	return implode( ' · ', array_filter( array_map( 'trim', $parts ) ) );
+}
+
+/**
  * Normalize book rating block attributes.
  *
  * @param array<string, mixed> $attrs Parsed block attributes.
@@ -66,14 +103,14 @@ function child_normalize_media_cover_grid_book_block( array $attrs ): ?array {
 		return null;
 	}
 
-	return [
+	return child_create_media_cover_grid_item( [
 		'type'        => 'book',
 		'title'       => $title,
 		'meta'        => trim( (string) ( $attrs['author'] ?? '' ) ),
-		'coverUrl'    => esc_url_raw( (string) ( $attrs['coverUrl'] ?? '' ) ),
+		'coverUrl'    => (string) ( $attrs['coverUrl'] ?? '' ),
 		'coverFormat' => 'portrait',
-		'externalUrl' => esc_url_raw( (string) ( $attrs['shopUrl'] ?? '' ) ),
-	];
+		'externalUrl' => (string) ( $attrs['shopUrl'] ?? '' ),
+	] );
 }
 
 /**
@@ -90,15 +127,15 @@ function child_normalize_media_cover_grid_media_recommendation_block( array $att
 
 	$media_type = 'tv' === ( $attrs['mediaType'] ?? '' ) ? 'tv' : 'movie';
 
-	return [
+	return child_create_media_cover_grid_item( [
 		'type'        => $media_type,
 		'title'       => $title,
 		'meta'        => trim( (string) ( $attrs['releaseYear'] ?? '' ) ),
-		'coverUrl'    => esc_url_raw( (string) ( $attrs['posterUrl'] ?? '' ) ),
+		'coverUrl'    => (string) ( $attrs['posterUrl'] ?? '' ),
 		'coverFormat' => 'portrait',
-		'externalUrl' => esc_url_raw( (string) ( $attrs['serviceUrl'] ?? '' ) ),
+		'externalUrl' => (string) ( $attrs['serviceUrl'] ?? '' ),
 		'tmdbId'      => absint( $attrs['tmdbId'] ?? 0 ),
-	];
+	] );
 }
 
 /**
@@ -120,17 +157,15 @@ function child_normalize_media_cover_grid_videogame_block( array $attrs ): ?arra
 		$year      = $timestamp ? date_i18n( 'Y', $timestamp ) : '';
 	}
 
-	$meta_parts = array_filter( [ $year, implode( ', ', array_slice( $platforms, 0, 3 ) ) ] );
-
-	return [
+	return child_create_media_cover_grid_item( [
 		'type'        => 'game',
 		'title'       => $title,
-		'meta'        => implode( ' · ', $meta_parts ),
-		'coverUrl'    => esc_url_raw( (string) ( $attrs['coverUrl'] ?? '' ) ),
+		'meta'        => child_join_media_cover_grid_meta( [ $year, implode( ', ', array_slice( $platforms, 0, 3 ) ) ] ),
+		'coverUrl'    => (string) ( $attrs['coverUrl'] ?? '' ),
 		'coverFormat' => 'landscape',
-		'externalUrl' => esc_url_raw( (string) ( $attrs['shopUrl'] ?? '' ) ),
+		'externalUrl' => (string) ( $attrs['shopUrl'] ?? '' ),
 		'rawgId'      => absint( $attrs['rawgId'] ?? 0 ),
-	];
+	] );
 }
 
 
@@ -149,17 +184,15 @@ function child_normalize_media_cover_grid_music_block( array $attrs ): ?array {
 	$artist       = trim( (string) ( $attrs['artist'] ?? '' ) );
 	$album_title  = trim( (string) ( $attrs['albumTitle'] ?? '' ) );
 	$release_year = trim( (string) ( $attrs['releaseYear'] ?? '' ) );
-	$meta_parts   = array_filter( [ $artist, 'song' === ( $attrs['musicType'] ?? '' ) ? $album_title : '', $release_year ] );
-
-	return [
+	return child_create_media_cover_grid_item( [
 		'type'        => 'music',
 		'title'       => $title,
-		'meta'        => implode( ' · ', $meta_parts ),
-		'coverUrl'    => esc_url_raw( (string) ( $attrs['coverUrl'] ?? '' ) ),
+		'meta'        => child_join_media_cover_grid_meta( [ $artist, 'song' === ( $attrs['musicType'] ?? '' ) ? $album_title : '', $release_year ] ),
+		'coverUrl'    => (string) ( $attrs['coverUrl'] ?? '' ),
 		'coverFormat' => 'square',
-		'externalUrl' => esc_url_raw( (string) ( $attrs['providerUrl'] ?? '' ) ),
+		'externalUrl' => (string) ( $attrs['providerUrl'] ?? '' ),
 		'providerId'  => sanitize_text_field( (string) ( $attrs['providerId'] ?? '' ) ),
-	];
+	] );
 }
 
 /**

--- a/inc/media-cover-grid.php
+++ b/inc/media-cover-grid.php
@@ -5,7 +5,7 @@
  * @package TwentyTwentyFiveChild
  */
 
-const CHILD_MEDIA_COVER_GRID_CACHE_KEY = 'child_media_cover_grid_items_v2';
+const CHILD_MEDIA_COVER_GRID_CACHE_KEY = 'child_media_cover_grid_items_v3';
 
 /**
  * Get the translated display label for a media-grid item type.
@@ -23,6 +23,33 @@ function child_get_media_cover_grid_type_label( string $type ): string {
 	];
 
 	return $labels[ $type ] ?? __( 'Medium', 'child' );
+}
+
+
+/**
+ * Get the validated cover format for a media-grid item.
+ *
+ * @param array<string, mixed> $item Media item.
+ * @return string
+ */
+function child_get_media_cover_grid_cover_format( array $item ): string {
+	$format = (string) ( $item['coverFormat'] ?? '' );
+
+	if ( in_array( $format, [ 'portrait', 'square', 'landscape' ], true ) ) {
+		return $format;
+	}
+
+	$type = (string) ( $item['type'] ?? '' );
+
+	if ( 'music' === $type ) {
+		return 'square';
+	}
+
+	if ( 'game' === $type ) {
+		return 'landscape';
+	}
+
+	return 'portrait';
 }
 
 /**

--- a/inc/media-cover-grid.php
+++ b/inc/media-cover-grid.php
@@ -52,6 +52,23 @@ function child_get_media_cover_grid_cover_format( array $item ): string {
 	return 'portrait';
 }
 
+
+/**
+ * Get the translated display label for a media-grid cover format.
+ *
+ * @param string $format Cover format.
+ * @return string
+ */
+function child_get_media_cover_grid_cover_format_label( string $format ): string {
+	$labels = [
+		'portrait'  => __( 'Hochformat', 'child' ),
+		'square'    => __( 'Quadratisch', 'child' ),
+		'landscape' => __( 'Querformat', 'child' ),
+	];
+
+	return $labels[ $format ] ?? __( 'Format', 'child' );
+}
+
 /**
  * Build the media item cache from published posts.
  *

--- a/inc/media-cover-grid.php
+++ b/inc/media-cover-grid.php
@@ -54,22 +54,6 @@ function child_get_media_cover_grid_cover_format( array $item ): string {
 
 
 /**
- * Get the translated display label for a media-grid cover format.
- *
- * @param string $format Cover format.
- * @return string
- */
-function child_get_media_cover_grid_cover_format_label( string $format ): string {
-	$labels = [
-		'portrait'  => __( 'Hochformat', 'child' ),
-		'square'    => __( 'Quadratisch', 'child' ),
-		'landscape' => __( 'Querformat', 'child' ),
-	];
-
-	return $labels[ $format ] ?? __( 'Format', 'child' );
-}
-
-/**
  * Build the media item cache from published posts.
  *
  * @param bool $allow_duplicates Whether duplicate media entries should be returned.


### PR DESCRIPTION
### Motivation
- Allow editors to filter and display media covers by format (portrait, square, landscape) so the grid can respect different aspect ratios per media type.

### Description
- Add a new `coverFormats` attribute to `block.json` and surface selectable format checkboxes in the block inspector using `COVER_FORMAT_OPTIONS` and `updateSelectedValues` in `index.js`.
- Include a `coverFormat` property in preview items and update the editor preview and empty-state message to require both a media type and a format selection.
- Wire cover formats through the server render: validate selected formats, filter items by format using `child_get_media_cover_grid_cover_format`, add format-specific class to cover markup in `render.php`, and adapt the empty message when no formats or types are selected.
- Persist inferred/default formats when normalizing blocks by adding `coverFormat` to normalized items for books/movies/tv (`portrait`), games (`landscape`), and music (`square`) in `media-cover-grid-normalizers.php`.
- Add `child_get_media_cover_grid_cover_format` helper and bump the cache key to `child_media_cover_grid_items_v3` in `inc/media-cover-grid.php` to validate and compute cover formats with sensible fallbacks.
- Add editor and front-end CSS rules to support portrait/square/landscape aspect ratios and inspector filter styles in `editor.css` and `style.css`.

### Testing
- Ran the JavaScript build and lint steps with `npm run build` and `npm run lint` and they completed without errors.
- Performed basic PHP syntax checks (`php -l`) on modified PHP files and they reported no parse errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4abc0ef7c8832590712937b95299d6)