### PR TITLE
Add IGDB portrait covers and coverFormat handling; update videogame block and media grid UI

### DIFF
--- a/blocks/media-cover-grid/block.json
+++ b/blocks/media-cover-grid/block.json
@@ -14,10 +14,6 @@
       "type": "array",
       "default": ["book", "movie", "tv", "game", "music"]
     },
-    "maxItems": {
-      "type": "number",
-      "default": 48
-    },
     "linkTo": {
       "type": "string",
       "default": "post"

--- a/blocks/media-cover-grid/index.js
+++ b/blocks/media-cover-grid/index.js
@@ -4,7 +4,6 @@ import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import {
     PanelBody,
     CheckboxControl,
-    RangeControl,
     SelectControl,
     ToggleControl
 } from '@wordpress/components';
@@ -72,7 +71,6 @@ const updateMediaTypes = (mediaTypes, value, checked) => {
 function Edit({ attributes, setAttributes }) {
     const {
         mediaTypes = metadata.attributes.mediaTypes.default,
-        maxItems = metadata.attributes.maxItems.default,
         linkTo = metadata.attributes.linkTo.default,
         sortOrder = metadata.attributes.sortOrder.default,
         showTitle = true,
@@ -101,14 +99,6 @@ function Edit({ attributes, setAttributes }) {
                             }
                         />
                     ))}
-
-                    <RangeControl
-                        label={__('Maximale Anzahl', 'child')}
-                        value={maxItems}
-                        onChange={(value) => setAttributes({ maxItems: value })}
-                        min={1}
-                        max={120}
-                    />
                 </PanelBody>
 
                 <PanelBody title={__('Darstellung', 'child')} initialOpen={true}>

--- a/blocks/media-cover-grid/render.php
+++ b/blocks/media-cover-grid/render.php
@@ -13,7 +13,6 @@ return function( array $attributes ): string {
 	$default_types     = [ 'book', 'movie', 'tv', 'game', 'music' ];
 	$media_types       = $attributes['mediaTypes'] ?? $default_types;
 	$allowed_types     = array_values( array_intersect( $default_types, is_array( $media_types ) ? $media_types : $default_types ) );
-	$max_items         = max( 1, min( 120, absint( $attributes['maxItems'] ?? 48 ) ) );
 	$link_to           = in_array( $attributes['linkTo'] ?? 'post', [ 'post', 'external', 'none' ], true ) ? $attributes['linkTo'] : 'post';
 	$sort_order        = in_array( $attributes['sortOrder'] ?? 'newest', [ 'newest', 'oldest', 'title' ], true ) ? $attributes['sortOrder'] : 'newest';
 	$show_title        = (bool) ( $attributes['showTitle'] ?? true );
@@ -53,7 +52,6 @@ return function( array $attributes ): string {
 		}
 	);
 
-	$items = array_slice( $items, 0, $max_items );
 	$item_types = array_values(
 		array_filter(
 			array_unique(
@@ -101,6 +99,11 @@ return function( array $attributes ): string {
 					$meta         = (string) ( $item['meta'] ?? '' );
 					$cover_url    = (string) ( $item['coverUrl'] ?? '' );
 					$cover_format = child_get_media_cover_grid_cover_format( $item );
+					$cover_dimensions = [
+						'portrait'  => [ 600, 900 ],
+						'square'    => [ 600, 600 ],
+						'landscape' => [ 1600, 900 ],
+					][ $cover_format ] ?? [ 600, 900 ];
 					$type_label   = child_get_media_cover_grid_type_label( $type );
 					$source_title  = (string) ( $item['sourcePostTitle'] ?? '' );
 					$source_timestamp = (int) ( $item['sourcePostTimestamp'] ?? 0 );
@@ -126,7 +129,16 @@ return function( array $attributes ): string {
 					<<?php echo tag_escape( $tag_name ); ?> class="child-media-cover-grid__item child-media-cover-grid__item--<?php echo esc_attr( $type ); ?>" data-child-media-type="<?php echo esc_attr( $type ); ?>"<?php echo $link_url ? ' href="' . esc_url( $link_url ) . '"' . $link_target . $link_rel : ''; ?> role="listitem" aria-label="<?php echo esc_attr( $title ); ?>">
 						<div class="child-media-cover-grid__cover child-media-cover-grid__cover--<?php echo esc_attr( $cover_format ); ?>">
 							<?php if ( $cover_url ) : ?>
-								<img src="<?php echo esc_url( $cover_url ); ?>" alt="<?php echo esc_attr( $title ); ?>" loading="lazy" />
+								<img
+									src="<?php echo esc_url( $cover_url ); ?>"
+									alt="<?php echo esc_attr( $title ); ?>"
+									loading="lazy"
+									decoding="async"
+									fetchpriority="low"
+									width="<?php echo esc_attr( (string) $cover_dimensions[0] ); ?>"
+									height="<?php echo esc_attr( (string) $cover_dimensions[1] ); ?>"
+									sizes="(max-width: 600px) calc((100vw - 3rem) / 2), (max-width: 900px) calc((100vw - 4rem) / 3), 180px"
+								/>
 							<?php else : ?>
 								<span class="child-media-cover-grid__placeholder" aria-hidden="true"><?php echo esc_html( substr( $type_label, 0, 1 ) ); ?></span>
 							<?php endif; ?>

--- a/blocks/media-cover-grid/render.php
+++ b/blocks/media-cover-grid/render.php
@@ -74,9 +74,9 @@ return function( array $attributes ): string {
 			<p class="child-media-cover-grid__empty"><?php echo esc_html__( 'Noch keine Medien gefunden.', 'child' ); ?></p>
 		<?php else : ?>
 			<?php if ( count( $item_types ) > 1 ) : ?>
-				<div class="child-media-cover-grid__controls" aria-label="<?php echo esc_attr__( 'Medien filtern', 'child' ); ?>">
-					<div class="child-media-cover-grid__control-group" role="group" aria-label="<?php echo esc_attr__( 'Medientypen', 'child' ); ?>">
-						<span class="child-media-cover-grid__control-label"><?php echo esc_html__( 'Typ', 'child' ); ?></span>
+				<div class="child-media-cover-grid__controls" role="group" aria-label="<?php echo esc_attr__( 'Medientypen', 'child' ); ?>">
+					<span class="child-media-cover-grid__control-label"><?php echo esc_html__( 'Typ', 'child' ); ?></span>
+					<div class="child-media-cover-grid__filter-list">
 						<button class="child-media-cover-grid__filter is-active" type="button" data-child-media-filter-group="type" data-child-media-filter-value="all" aria-pressed="true">
 							<?php echo esc_html__( 'Alle', 'child' ); ?>
 						</button>

--- a/blocks/media-cover-grid/style.css
+++ b/blocks/media-cover-grid/style.css
@@ -5,28 +5,30 @@
 
 .child-media-cover-grid__controls {
   align-items: center;
-  background: color-mix(in srgb, #ffffff 88%, currentColor 12%);
-  border: 1px solid color-mix(in srgb, currentColor 10%, transparent);
-  border-radius: 999px;
-  box-shadow: 0 10px 28px color-mix(in srgb, currentColor 7%, transparent);
-  display: inline-flex;
-  gap: 0.2rem;
+  display: flex;
+  gap: clamp(0.75rem, 2vw, 1rem);
   justify-content: flex-start;
   margin-block-end: clamp(1.1rem, 2vw, 1.7rem);
   margin-inline: auto;
   max-width: 100%;
-  overflow: hidden;
-  padding: 0.3rem;
+  width: fit-content;
 }
 
 .child-media-cover-grid__filter-list {
+  background: #dfe2e5;
+  border: 1px solid color-mix(in srgb, currentColor 12%, transparent);
+  border-radius: 999px;
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, #ffffff 38%, transparent),
+    0 14px 32px rgba(15, 23, 42, 0.08);
   display: inline-flex;
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   flex-wrap: nowrap;
-  gap: 0.2rem;
+  gap: clamp(0.45rem, 1.5vw, 1.1rem);
   min-width: 0;
   overflow-x: auto;
   overflow-y: hidden;
+  padding: 0.45rem;
   scrollbar-width: none;
   -webkit-overflow-scrolling: touch;
 }
@@ -38,11 +40,10 @@
 .child-media-cover-grid__control-label {
   color: color-mix(in srgb, currentColor 62%, transparent);
   flex: 0 0 auto;
-  font-size: 0.68rem;
+  font-size: clamp(0.72rem, 1.8vw, 0.88rem);
   font-weight: 700;
-  letter-spacing: 0.08em;
-  margin-inline-end: 0.35rem;
-  padding-inline-start: 0.65rem;
+  letter-spacing: 0.1em;
+  line-height: 1;
   text-transform: uppercase;
 }
 
@@ -54,10 +55,11 @@
   cursor: pointer;
   font: inherit;
   font-size: 0.82rem;
-  font-weight: 600;
+  font-weight: 700;
   line-height: 1.2;
-  min-height: 2.3rem;
-  padding: 0.5rem 0.9rem;
+  min-height: clamp(2.65rem, 6vw, 3.75rem);
+  min-width: clamp(4.3rem, 11vw, 6.8rem);
+  padding: 0.6rem clamp(0.8rem, 2.2vw, 1.45rem);
   white-space: nowrap;
   transition: background-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
 }
@@ -77,7 +79,7 @@
 
 .child-media-cover-grid__filter.is-active {
   background: #fff;
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.08);
   color: inherit;
 }
 
@@ -92,9 +94,11 @@
 }
 
 .child-media-cover-grid__item {
+  align-self: start;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 24rem;
   color: inherit;
   display: block;
-  align-self: start;
   min-width: 0;
   text-decoration: none;
 }
@@ -128,10 +132,6 @@
 
 .child-media-cover-grid__item[hidden] {
   display: none;
-}
-
-.child-media-cover-grid__item--game {
-  grid-column: span 2;
 }
 
 .child-media-cover-grid__item:is(a):hover .child-media-cover-grid__cover,
@@ -232,16 +232,6 @@
 }
 
 @media (max-width: 600px) {
-  .child-media-cover-grid__control-group {
-    border-radius: 24px;
-  }
-
-  .child-media-cover-grid__control-label {
-    flex-basis: 100%;
-    margin-inline-end: 0;
-    padding: 0.3rem 0.45rem 0.1rem;
-  }
-
   .child-media-cover-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -251,17 +241,32 @@
   }
 }
 
-.child-media-cover-grid__control-group::-webkit-scrollbar {
-  display: none;
-}
-
 @media (max-width: 600px) {
   .child-media-cover-grid__controls {
+    align-items: center;
+    flex-direction: row;
+    gap: 0;
     justify-content: flex-start;
+    margin-inline: 0;
+    width: 100%;
   }
 
-  .child-media-cover-grid__control-group {
-    border-radius: 28px;
+  .child-media-cover-grid__control-label {
+    display: none;
+  }
+
+  .child-media-cover-grid__filter-list {
+    box-sizing: border-box;
+    gap: 0.25rem;
+    max-width: 100%;
+    padding: 0.32rem;
     width: 100%;
+  }
+
+  .child-media-cover-grid__filter {
+    flex: 0 0 auto;
+    min-height: 2.7rem;
+    min-width: 4rem;
+    padding: 0.55rem 0.85rem;
   }
 }

--- a/blocks/media-cover-grid/style.css
+++ b/blocks/media-cover-grid/style.css
@@ -4,33 +4,40 @@
 }
 
 .child-media-cover-grid__controls {
-  display: flex;
-  justify-content: center;
-  margin-block-end: clamp(1.1rem, 2vw, 1.7rem);
-  max-width: 100%;
-  overflow: hidden;
-}
-
-.child-media-cover-grid__control-group {
   align-items: center;
   background: color-mix(in srgb, #ffffff 88%, currentColor 12%);
   border: 1px solid color-mix(in srgb, currentColor 10%, transparent);
   border-radius: 999px;
   box-shadow: 0 10px 28px color-mix(in srgb, currentColor 7%, transparent);
   display: inline-flex;
-  flex: 0 1 auto;
+  gap: 0.2rem;
+  justify-content: flex-start;
+  margin-block-end: clamp(1.1rem, 2vw, 1.7rem);
+  margin-inline: auto;
+  max-width: 100%;
+  overflow: hidden;
+  padding: 0.3rem;
+}
+
+.child-media-cover-grid__filter-list {
+  display: inline-flex;
+  flex: 1 1 auto;
   flex-wrap: nowrap;
   gap: 0.2rem;
-  max-width: 100%;
+  min-width: 0;
   overflow-x: auto;
   overflow-y: hidden;
-  padding: 0.3rem;
   scrollbar-width: none;
   -webkit-overflow-scrolling: touch;
 }
 
+.child-media-cover-grid__filter-list::-webkit-scrollbar {
+  display: none;
+}
+
 .child-media-cover-grid__control-label {
   color: color-mix(in srgb, currentColor 62%, transparent);
+  flex: 0 0 auto;
   font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.08em;

--- a/blocks/media-cover-grid/view.js
+++ b/blocks/media-cover-grid/view.js
@@ -37,9 +37,16 @@ const updateGrid = ( block ) => {
 
 	block.querySelectorAll( ITEM_SELECTOR ).forEach( ( item ) => {
 		const isVisible = activeTypes === null || activeTypes.has( item.dataset.childMediaType );
+		const shouldHide = ! isVisible;
+		const ariaHidden = isVisible ? 'false' : 'true';
 
-		item.hidden = ! isVisible;
-		item.setAttribute( 'aria-hidden', isVisible ? 'false' : 'true' );
+		if ( item.hidden !== shouldHide ) {
+			item.hidden = shouldHide;
+		}
+
+		if ( item.getAttribute( 'aria-hidden' ) !== ariaHidden ) {
+			item.setAttribute( 'aria-hidden', ariaHidden );
+		}
 
 		if ( isVisible ) {
 			visibleItems += 1;

--- a/blocks/videogame-recommendation/README.md
+++ b/blocks/videogame-recommendation/README.md
@@ -1,10 +1,11 @@
 # Videogame Recommendation Block
 
-A WordPress Gutenberg block for displaying videogame recommendations with RAWG API integration.
+A WordPress Gutenberg block for displaying videogame recommendations with RAWG metadata and optional IGDB portrait cover integration.
 
 ## Features
 
 - **RAWG API integration:** Search games and import metadata automatically.
+- **IGDB portrait covers:** Optionally enrich RAWG results with portrait box-art covers from IGDB.
 - **Light mode design:** Modern card UI inspired by RAWG.
 - **Platform chips:** Color-coded badges for gaming platforms.
 - **Metadata:** Release date and genre display.
@@ -81,3 +82,5 @@ npm run start
 ## API
 
 Uses the RAWG API for game data. Configure the API key in WordPress Admin under **Settings → Videogame Recommendation**.
+
+Optional IGDB credentials can be added on the same settings page to fetch portrait videogame covers. The credentials can also be supplied via `IGDB_CLIENT_ID` and `IGDB_CLIENT_SECRET` constants in `wp-config.php`; values saved in WordPress override the constants.

--- a/blocks/videogame-recommendation/README.md
+++ b/blocks/videogame-recommendation/README.md
@@ -1,11 +1,11 @@
 # Videogame Recommendation Block
 
-A WordPress Gutenberg block for displaying videogame recommendations with RAWG metadata and optional IGDB portrait cover integration.
+A WordPress Gutenberg block for displaying videogame recommendations with RAWG metadata and optional SteamGridDB portrait cover integration.
 
 ## Features
 
 - **RAWG API integration:** Search games and import metadata automatically.
-- **IGDB portrait covers:** Optionally enrich RAWG results with portrait box-art covers from IGDB.
+- **SteamGridDB portrait covers:** Optionally enrich RAWG results with portrait box-art covers from SteamGridDB.
 - **Light mode design:** Modern card UI inspired by RAWG.
 - **Platform chips:** Color-coded badges for gaming platforms.
 - **Metadata:** Release date and genre display.
@@ -83,4 +83,4 @@ npm run start
 
 Uses the RAWG API for game data. Configure the API key in WordPress Admin under **Settings → Videogame Recommendation**.
 
-Optional IGDB credentials can be added on the same settings page to fetch portrait videogame covers. The credentials can also be supplied via `IGDB_CLIENT_ID` and `IGDB_CLIENT_SECRET` constants in `wp-config.php`; values saved in WordPress override the constants.
+An optional SteamGridDB API key can be added on the same settings page to fetch portrait videogame covers. The key can also be supplied via a `STEAMGRIDDB_API_KEY` constant in `wp-config.php`; values saved in WordPress override the constant.

--- a/blocks/videogame-recommendation/block.json
+++ b/blocks/videogame-recommendation/block.json
@@ -17,6 +17,10 @@
       "type": "string",
       "default": ""
     },
+    "coverFormat": {
+      "type": "string",
+      "default": "landscape"
+    },
     "releaseYear": {
       "type": "string",
       "default": ""

--- a/blocks/videogame-recommendation/block.json
+++ b/blocks/videogame-recommendation/block.json
@@ -21,6 +21,10 @@
       "type": "string",
       "default": "landscape"
     },
+    "coverVariants": {
+      "type": "array",
+      "default": []
+    },
     "releaseYear": {
       "type": "string",
       "default": ""

--- a/blocks/videogame-recommendation/components/GamePreview.js
+++ b/blocks/videogame-recommendation/components/GamePreview.js
@@ -5,7 +5,7 @@ import { getPlatformInfo, formatReleaseDate } from '../utils';
  * GamePreview Component
  * Displays a game card with cover image, platforms, title, and metadata
  */
-export const GamePreview = ({ gameTitle, coverUrl, releaseDate, platforms, genres, shopUrl }) => {
+export const GamePreview = ({ gameTitle, coverUrl, coverFormat = 'landscape', releaseDate, platforms, genres, shopUrl }) => {
 	if (!gameTitle?.trim()) {
 		return (
 			<div className="game-preview--empty">
@@ -16,10 +16,11 @@ export const GamePreview = ({ gameTitle, coverUrl, releaseDate, platforms, genre
 
 	const formattedDate = formatReleaseDate(releaseDate);
 	const coverLink = shopUrl?.trim();
+	const mediaClassName = `child-game-card__media child-game-card__media--${coverFormat === 'landscape' ? 'landscape' : 'portrait'}`;
 
 	return (
 		<div className="child-game-card" aria-label={__('Videospiel', 'child')}>
-			<div className="child-game-card__media">
+			<div className={mediaClassName}>
 				{coverUrl ? (
 					coverLink ? (
 						<a

--- a/blocks/videogame-recommendation/editor.css
+++ b/blocks/videogame-recommendation/editor.css
@@ -109,6 +109,49 @@
 	text-overflow: ellipsis;
 }
 
+.game-cover-variants {
+	margin-top: 1rem;
+}
+
+.game-cover-variants__label {
+	color: #1e1e1e;
+	font-size: 11px;
+	font-weight: 500;
+	line-height: 1.4;
+	margin-bottom: 0.5rem;
+	text-transform: uppercase;
+}
+
+.game-cover-variants__list {
+	display: grid;
+	gap: 0.5rem;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.game-cover-variants__button.components-button {
+	aspect-ratio: 2 / 3;
+	border: 2px solid transparent;
+	border-radius: 6px;
+	box-shadow: none;
+	height: auto;
+	min-width: 0;
+	overflow: hidden;
+	padding: 0;
+	width: 100%;
+}
+
+.game-cover-variants__button.components-button.is-active {
+	border-color: var(--wp-admin-theme-color, #3858e9);
+	box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #3858e9);
+}
+
+.game-cover-variants__button img {
+	display: block;
+	height: 100%;
+	object-fit: cover;
+	width: 100%;
+}
+
 /* Empty State */
 .game-preview--empty {
 	margin-top: 1.5rem;

--- a/blocks/videogame-recommendation/index.js
+++ b/blocks/videogame-recommendation/index.js
@@ -43,6 +43,7 @@ function Edit({ attributes, setAttributes }) {
 			gameTitle: selectedGame.title,
 			coverUrl: selectedGame.cover,
 			coverFormat: selectedGame.coverFormat,
+			coverVariants: selectedGame.coverVariants,
 			releaseYear: selectedGame.year,
 			releaseDate: selectedGame.releaseDate,
 			platforms: selectedGame.platforms,
@@ -114,8 +115,16 @@ function Edit({ attributes, setAttributes }) {
 					<TextControl __next40pxDefaultSize __nextHasNoMarginBottom
 						label={__('Cover-URL', 'child')}
 						value={attributes.coverUrl}
-						onChange={(value) => setAttributes({ coverUrl: value })}
+						onChange={(value) => setAttributes({ coverUrl: value, coverVariants: [] })}
 						help={__('Optional: Eigenes Cover einfügen', 'child')}
+					/>
+					<CoverVariantPicker
+						variants={attributes.coverVariants}
+						selectedUrl={attributes.coverUrl}
+						onSelect={(variant) => setAttributes({
+							coverUrl: variant.url,
+							coverFormat: variant.coverFormat || 'portrait'
+						})}
 					/>
 					<TextControl __next40pxDefaultSize __nextHasNoMarginBottom
 						label={__('Shop-Link', 'child')}
@@ -130,6 +139,37 @@ function Edit({ attributes, setAttributes }) {
 		</div>
 	);
 }
+
+const CoverVariantPicker = ({ variants = [], selectedUrl, onSelect }) => {
+	if (!variants.length) {
+		return null;
+	}
+
+	return (
+		<div className="game-cover-variants">
+			<div className="game-cover-variants__label">
+				{__('SteamGridDB-Cover', 'child')}
+			</div>
+			<div className="game-cover-variants__list">
+				{variants.map((variant, index) => {
+					const isSelected = variant.url === selectedUrl;
+
+					return (
+						<Button
+							key={`${variant.url}-${index}`}
+							className={`game-cover-variants__button${isSelected ? ' is-active' : ''}`}
+							onClick={() => onSelect(variant)}
+							aria-label={__('Cover auswählen', 'child')}
+							aria-pressed={isSelected}
+						>
+							<img src={variant.url} alt="" loading="lazy" />
+						</Button>
+					);
+				})}
+			</div>
+		</div>
+	);
+};
 
 registerBlockType(metadata.name, {
 	edit: Edit,

--- a/blocks/videogame-recommendation/index.js
+++ b/blocks/videogame-recommendation/index.js
@@ -42,6 +42,7 @@ function Edit({ attributes, setAttributes }) {
 		setAttributes({
 			gameTitle: selectedGame.title,
 			coverUrl: selectedGame.cover,
+			coverFormat: selectedGame.coverFormat,
 			releaseYear: selectedGame.year,
 			releaseDate: selectedGame.releaseDate,
 			platforms: selectedGame.platforms,

--- a/blocks/videogame-recommendation/style.css
+++ b/blocks/videogame-recommendation/style.css
@@ -28,11 +28,21 @@
 
 /* Media Container */
 .child-game-card__media {
+	align-self: center;
 	position: relative;
 	width: 100%;
-	aspect-ratio: 16 / 9;
+	aspect-ratio: 2 / 3;
 	background: #f5f5f5;
 	overflow: hidden;
+}
+
+.child-game-card__media--portrait {
+	max-width: min(100%, 340px);
+}
+
+.child-game-card__media--landscape {
+	aspect-ratio: 16 / 9;
+	max-width: 100%;
 }
 
 .child-game-card__cover {

--- a/blocks/videogame-recommendation/utils.js
+++ b/blocks/videogame-recommendation/utils.js
@@ -78,7 +78,8 @@ export const transformGameData = (game) => {
 		title: game.name || '',
 		year: game.released ? new Date(game.released).getFullYear().toString() : '',
 		releaseDate: game.released || '',
-		cover: normalizeImageUrl(game.background_image),
+		cover: normalizeImageUrl(game.cover_url || game.background_image),
+		coverFormat: game.cover_format || (game.cover_url ? 'portrait' : 'landscape'),
 		shopUrl: game.website || (game.slug ? `https://rawg.io/games/${game.slug}` : ''),
 		platforms: game.platforms || [],
 		genres: game.genres || []

--- a/blocks/videogame-recommendation/utils.js
+++ b/blocks/videogame-recommendation/utils.js
@@ -72,6 +72,8 @@ export const normalizeImageUrl = (url) => {
  * @returns {Object} - Transformed game data
  */
 export const transformGameData = (game) => {
+	const coverVariants = Array.isArray(game.cover_variants) ? game.cover_variants : [];
+
 	return {
 		id: `game-${game.id}`,
 		rawgId: game.id,
@@ -80,6 +82,14 @@ export const transformGameData = (game) => {
 		releaseDate: game.released || '',
 		cover: normalizeImageUrl(game.cover_url || game.background_image),
 		coverFormat: game.cover_format || (game.cover_url ? 'portrait' : 'landscape'),
+		coverVariants: coverVariants
+			.map((variant) => ({
+				url: normalizeImageUrl(variant.url),
+				coverFormat: variant.cover_format || 'portrait',
+				width: variant.width || 0,
+				height: variant.height || 0
+			}))
+			.filter((variant) => variant.url),
 		shopUrl: game.website || (game.slug ? `https://rawg.io/games/${game.slug}` : ''),
 		platforms: game.platforms || [],
 		genres: game.genres || []

--- a/inc/media-cover-grid-normalizers.php
+++ b/inc/media-cover-grid-normalizers.php
@@ -162,7 +162,7 @@ function child_normalize_media_cover_grid_videogame_block( array $attrs ): ?arra
 		'title'       => $title,
 		'meta'        => child_join_media_cover_grid_meta( [ $year, implode( ', ', array_slice( $platforms, 0, 3 ) ) ] ),
 		'coverUrl'    => (string) ( $attrs['coverUrl'] ?? '' ),
-		'coverFormat' => 'landscape',
+		'coverFormat' => 'portrait' === ( $attrs['coverFormat'] ?? '' ) ? 'portrait' : 'landscape',
 		'externalUrl' => (string) ( $attrs['shopUrl'] ?? '' ),
 		'rawgId'      => absint( $attrs['rawgId'] ?? 0 ),
 	] );

--- a/inc/videogame-recommendation.php
+++ b/inc/videogame-recommendation.php
@@ -61,34 +61,43 @@ function child_request_steamgriddb_api( string $path ): array {
 }
 
 /**
- * Pick the best portrait SteamGridDB grid image from an API response.
+ * Normalize portrait SteamGridDB grid images from an API response.
+ *
+ * @return array<int, array{url: string, cover_format: string, width: int, height: int}>
  */
-function child_pick_steamgriddb_portrait_grid( array $grids ): array {
+function child_normalize_steamgriddb_portrait_grids( array $grids ): array {
+	$variants = [];
+	$seen     = [];
+
 	foreach ( $grids as $grid ) {
 		if ( ! is_array( $grid ) || empty( $grid['url'] ) ) {
 			continue;
 		}
 
+		$url    = esc_url_raw( (string) $grid['url'] );
 		$width  = absint( $grid['width'] ?? 0 );
 		$height = absint( $grid['height'] ?? 0 );
 
-		if ( $width > 0 && $height > 0 && $height <= $width ) {
+		if ( '' === $url || isset( $seen[ $url ] ) || ( $width > 0 && $height > 0 && $height <= $width ) ) {
 			continue;
 		}
 
-		return [
-			'cover_url'    => esc_url_raw( (string) $grid['url'] ),
+		$variants[] = [
+			'url'          => $url,
 			'cover_format' => 'portrait',
+			'width'        => $width,
+			'height'       => $height,
 		];
+		$seen[ $url ] = true;
 	}
 
-	return [];
+	return array_slice( $variants, 0, 12 );
 }
 
 /**
- * Fetch a portrait cover from SteamGridDB by game title.
+ * Fetch portrait cover variants from SteamGridDB by game title.
  */
-function child_find_steamgriddb_cover_for_game( string $title ): array {
+function child_find_steamgriddb_covers_for_game( string $title ): array {
 	$title = trim( $title );
 	if ( '' === $title || '' === child_get_steamgriddb_api_key() ) {
 		return [];
@@ -104,15 +113,16 @@ function child_find_steamgriddb_cover_for_game( string $title ): array {
 		return [];
 	}
 
-	$grids = child_request_steamgriddb_api( 'grids/game/' . $game_id . '?dimensions=600x900' );
-	$cover = child_pick_steamgriddb_portrait_grid( $grids );
-	if ( [] !== $cover ) {
-		return $cover;
+	$variants = child_normalize_steamgriddb_portrait_grids(
+		child_request_steamgriddb_api( 'grids/game/' . $game_id . '?dimensions=600x900' )
+	);
+	if ( [] !== $variants ) {
+		return $variants;
 	}
 
-	$grids = child_request_steamgriddb_api( 'grids/game/' . $game_id );
-
-	return child_pick_steamgriddb_portrait_grid( $grids );
+	return child_normalize_steamgriddb_portrait_grids(
+		child_request_steamgriddb_api( 'grids/game/' . $game_id )
+	);
 }
 
 /**
@@ -296,9 +306,9 @@ function child_handle_rawg_search_ajax(): void {
 
 	$games = array_map(
 		static function( array $game ): array {
-			$steamgriddb_cover  = child_find_steamgriddb_cover_for_game( (string) ( $game['name'] ?? '' ) );
-			$cover_url    = (string) ( $steamgriddb_cover['cover_url'] ?? '' );
-			$cover_format = (string) ( $steamgriddb_cover['cover_format'] ?? '' );
+			$steamgriddb_covers = child_find_steamgriddb_covers_for_game( (string) ( $game['name'] ?? '' ) );
+			$cover_url          = (string) ( $steamgriddb_covers[0]['url'] ?? '' );
+			$cover_format       = (string) ( $steamgriddb_covers[0]['cover_format'] ?? '' );
 
 			return [
 				'id'               => $game['id'] ?? 0,
@@ -307,6 +317,7 @@ function child_handle_rawg_search_ajax(): void {
 				'background_image' => $game['background_image'] ?? '',
 				'cover_url'        => $cover_url,
 				'cover_format'     => $cover_format ?: 'landscape',
+				'cover_variants'   => $steamgriddb_covers,
 				'slug'             => $game['slug'] ?? '',
 				'website'          => $game['website'] ?? '',
 				'platforms'        => array_map(

--- a/inc/videogame-recommendation.php
+++ b/inc/videogame-recommendation.php
@@ -19,6 +19,136 @@ function child_get_rawg_api_key(): string {
 }
 
 /**
+ * Read IGDB client ID from option, then constant fallback.
+ */
+function child_get_igdb_client_id(): string {
+	$client_id = (string) get_option( 'child_igdb_client_id', '' );
+
+	if ( '' === $client_id && defined( 'IGDB_CLIENT_ID' ) ) {
+		$client_id = (string) IGDB_CLIENT_ID;
+	}
+
+	return $client_id;
+}
+
+/**
+ * Read IGDB client secret from option, then constant fallback.
+ */
+function child_get_igdb_client_secret(): string {
+	$client_secret = (string) get_option( 'child_igdb_client_secret', '' );
+
+	if ( '' === $client_secret && defined( 'IGDB_CLIENT_SECRET' ) ) {
+		$client_secret = (string) IGDB_CLIENT_SECRET;
+	}
+
+	return $client_secret;
+}
+
+/**
+ * Get a cached Twitch app token for IGDB requests.
+ */
+function child_get_igdb_access_token(): string {
+	$client_id     = child_get_igdb_client_id();
+	$client_secret = child_get_igdb_client_secret();
+
+	if ( '' === $client_id || '' === $client_secret ) {
+		return '';
+	}
+
+	$cached_token = get_transient( 'child_igdb_access_token' );
+	if ( is_string( $cached_token ) && '' !== $cached_token ) {
+		return $cached_token;
+	}
+
+	$response = wp_safe_remote_post(
+		'https://id.twitch.tv/oauth2/token',
+		[
+			'timeout' => 10,
+			'body'    => [
+				'client_id'     => $client_id,
+				'client_secret' => $client_secret,
+				'grant_type'    => 'client_credentials',
+			],
+		]
+	);
+
+	if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		return '';
+	}
+
+	$data         = json_decode( wp_remote_retrieve_body( $response ), true );
+	$access_token = is_array( $data ) ? (string) ( $data['access_token'] ?? '' ) : '';
+	$expires_in   = is_array( $data ) ? absint( $data['expires_in'] ?? HOUR_IN_SECONDS ) : HOUR_IN_SECONDS;
+
+	if ( '' === $access_token ) {
+		return '';
+	}
+
+	set_transient( 'child_igdb_access_token', $access_token, max( HOUR_IN_SECONDS, $expires_in - 300 ) );
+
+	return $access_token;
+}
+
+/**
+ * Build an IGDB image URL for a cover image ID.
+ */
+function child_build_igdb_cover_url( string $image_id, string $size = 'cover_big' ): string {
+	$image_id = preg_replace( '/[^a-zA-Z0-9_-]/', '', $image_id );
+	$size     = preg_replace( '/[^a-zA-Z0-9_]/', '', $size );
+
+	if ( '' === $image_id ) {
+		return '';
+	}
+
+	return esc_url_raw( sprintf( 'https://images.igdb.com/igdb/image/upload/t_%s/%s.jpg', $size ?: 'cover_big', $image_id ) );
+}
+
+/**
+ * Fetch a portrait cover from IGDB by game title.
+ */
+function child_find_igdb_cover_for_game( string $title ): array {
+	$title        = trim( $title );
+	$client_id    = child_get_igdb_client_id();
+	$access_token = child_get_igdb_access_token();
+
+	if ( '' === $title || '' === $client_id || '' === $access_token ) {
+		return [];
+	}
+
+	$response = wp_safe_remote_post(
+		'https://api.igdb.com/v4/games',
+		[
+			'timeout' => 10,
+			'headers' => [
+				'Accept'        => 'application/json',
+				'Authorization' => 'Bearer ' . $access_token,
+				'Client-ID'     => $client_id,
+			],
+			'body'    => sprintf(
+				'search "%s"; fields cover.image_id,cover.width,cover.height; where cover != null; limit 1;',
+				addcslashes( $title, '\\"' )
+			),
+		]
+	);
+
+	if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		return [];
+	}
+
+	$data  = json_decode( wp_remote_retrieve_body( $response ), true );
+	$cover = is_array( $data[0]['cover'] ?? null ) ? $data[0]['cover'] : [];
+
+	if ( empty( $cover['image_id'] ) ) {
+		return [];
+	}
+
+	return [
+		'cover_url'    => child_build_igdb_cover_url( (string) $cover['image_id'], 'cover_big' ),
+		'cover_format' => 'portrait',
+	];
+}
+
+/**
  * Render RAWG settings page.
  */
 function child_render_videogame_recommendation_settings_page(): void {
@@ -64,6 +194,26 @@ function child_register_videogame_recommendation_settings(): void {
 		]
 	);
 
+	register_setting(
+		'child_videogame_recommendation',
+		'child_igdb_client_id',
+		[
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_text_field',
+			'default'           => '',
+		]
+	);
+
+	register_setting(
+		'child_videogame_recommendation',
+		'child_igdb_client_secret',
+		[
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_text_field',
+			'default'           => '',
+		]
+	);
+
 	add_settings_section(
 		'child_videogame_recommendation_section',
 		__( 'RAWG API Configuration', 'child' ),
@@ -78,6 +228,22 @@ function child_register_videogame_recommendation_settings(): void {
 		'child-videogame-recommendation',
 		'child_videogame_recommendation_section'
 	);
+
+	add_settings_field(
+		'child_igdb_client_id',
+		__( 'IGDB Client ID', 'child' ),
+		'child_render_igdb_client_id_field',
+		'child-videogame-recommendation',
+		'child_videogame_recommendation_section'
+	);
+
+	add_settings_field(
+		'child_igdb_client_secret',
+		__( 'IGDB Client Secret', 'child' ),
+		'child_render_igdb_client_secret_field',
+		'child-videogame-recommendation',
+		'child_videogame_recommendation_section'
+	);
 }
 add_action( 'admin_init', 'child_register_videogame_recommendation_settings' );
 
@@ -88,7 +254,7 @@ function child_render_videogame_recommendation_section_description(): void {
 	echo '<p>' . wp_kses_post(
 		sprintf(
 			/* translators: %s: URL to RAWG API docs */
-			__( 'To use the Videogame Recommendation block, you need a free API key from RAWG. Get your API key at %s.', 'child' ),
+			__( 'To use the Videogame Recommendation block, you need a free API key from RAWG. Add optional IGDB credentials to enrich results with portrait game covers. Get your RAWG API key at %s.', 'child' ),
 			'<a href="https://rawg.io/apidocs" target="_blank" rel="noopener noreferrer">rawg.io/apidocs</a>'
 		)
 	) . '</p>';
@@ -109,6 +275,40 @@ function child_render_videogame_recommendation_api_field(): void {
 	}
 
 	echo '<p class="description">' . esc_html__( 'Your API key will be stored securely in the database.', 'child' ) . '</p>';
+}
+
+/**
+ * Render IGDB client ID input.
+ */
+function child_render_igdb_client_id_field(): void {
+	$value        = (string) get_option( 'child_igdb_client_id', '' );
+	$has_constant = defined( 'IGDB_CLIENT_ID' ) && ! empty( IGDB_CLIENT_ID );
+
+	echo '<input type="text" id="child_igdb_client_id" name="child_igdb_client_id" value="' . esc_attr( $value ) . '" class="regular-text" placeholder="' . esc_attr__( 'Enter your IGDB Client ID', 'child' ) . '" />';
+
+	if ( $has_constant && '' === $value ) {
+		echo '<p class="description">' . esc_html__( 'Currently using IGDB Client ID from wp-config.php. Enter a value here to override it.', 'child' ) . '</p>';
+		return;
+	}
+
+	echo '<p class="description">' . esc_html__( 'Optional: Used to fetch portrait videogame covers from IGDB.', 'child' ) . '</p>';
+}
+
+/**
+ * Render IGDB client secret input.
+ */
+function child_render_igdb_client_secret_field(): void {
+	$value        = (string) get_option( 'child_igdb_client_secret', '' );
+	$has_constant = defined( 'IGDB_CLIENT_SECRET' ) && ! empty( IGDB_CLIENT_SECRET );
+
+	echo '<input type="password" id="child_igdb_client_secret" name="child_igdb_client_secret" value="' . esc_attr( $value ) . '" class="regular-text" placeholder="' . esc_attr__( 'Enter your IGDB Client Secret', 'child' ) . '" autocomplete="new-password" />';
+
+	if ( $has_constant && '' === $value ) {
+		echo '<p class="description">' . esc_html__( 'Currently using IGDB Client Secret from wp-config.php. Enter a value here to override it.', 'child' ) . '</p>';
+		return;
+	}
+
+	echo '<p class="description">' . esc_html__( 'Optional: Stored in the database and only used server-side for IGDB access tokens.', 'child' ) . '</p>';
 }
 
 /**
@@ -163,11 +363,17 @@ function child_handle_rawg_search_ajax(): void {
 
 	$games = array_map(
 		static function( array $game ): array {
+			$igdb_cover  = child_find_igdb_cover_for_game( (string) ( $game['name'] ?? '' ) );
+			$cover_url   = (string) ( $igdb_cover['cover_url'] ?? '' );
+			$cover_format = (string) ( $igdb_cover['cover_format'] ?? '' );
+
 			return [
 				'id'               => $game['id'] ?? 0,
 				'name'             => $game['name'] ?? '',
 				'released'         => $game['released'] ?? '',
 				'background_image' => $game['background_image'] ?? '',
+				'cover_url'        => $cover_url,
+				'cover_format'     => $cover_format ?: 'landscape',
 				'slug'             => $game['slug'] ?? '',
 				'website'          => $game['website'] ?? '',
 				'platforms'        => array_map(

--- a/inc/videogame-recommendation.php
+++ b/inc/videogame-recommendation.php
@@ -19,115 +19,35 @@ function child_get_rawg_api_key(): string {
 }
 
 /**
- * Read IGDB client ID from option, then constant fallback.
+ * Read SteamGridDB key from option, then constant fallback.
  */
-function child_get_igdb_client_id(): string {
-	$client_id = (string) get_option( 'child_igdb_client_id', '' );
+function child_get_steamgriddb_api_key(): string {
+	$api_key = (string) get_option( 'child_steamgriddb_api_key', '' );
 
-	if ( '' === $client_id && defined( 'IGDB_CLIENT_ID' ) ) {
-		$client_id = (string) IGDB_CLIENT_ID;
+	if ( '' === $api_key && defined( 'STEAMGRIDDB_API_KEY' ) ) {
+		$api_key = (string) STEAMGRIDDB_API_KEY;
 	}
 
-	return $client_id;
+	return $api_key;
 }
 
 /**
- * Read IGDB client secret from option, then constant fallback.
+ * Perform a SteamGridDB API request.
  */
-function child_get_igdb_client_secret(): string {
-	$client_secret = (string) get_option( 'child_igdb_client_secret', '' );
-
-	if ( '' === $client_secret && defined( 'IGDB_CLIENT_SECRET' ) ) {
-		$client_secret = (string) IGDB_CLIENT_SECRET;
-	}
-
-	return $client_secret;
-}
-
-/**
- * Get a cached Twitch app token for IGDB requests.
- */
-function child_get_igdb_access_token(): string {
-	$client_id     = child_get_igdb_client_id();
-	$client_secret = child_get_igdb_client_secret();
-
-	if ( '' === $client_id || '' === $client_secret ) {
-		return '';
-	}
-
-	$cached_token = get_transient( 'child_igdb_access_token' );
-	if ( is_string( $cached_token ) && '' !== $cached_token ) {
-		return $cached_token;
-	}
-
-	$response = wp_safe_remote_post(
-		'https://id.twitch.tv/oauth2/token',
-		[
-			'timeout' => 10,
-			'body'    => [
-				'client_id'     => $client_id,
-				'client_secret' => $client_secret,
-				'grant_type'    => 'client_credentials',
-			],
-		]
-	);
-
-	if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-		return '';
-	}
-
-	$data         = json_decode( wp_remote_retrieve_body( $response ), true );
-	$access_token = is_array( $data ) ? (string) ( $data['access_token'] ?? '' ) : '';
-	$expires_in   = is_array( $data ) ? absint( $data['expires_in'] ?? HOUR_IN_SECONDS ) : HOUR_IN_SECONDS;
-
-	if ( '' === $access_token ) {
-		return '';
-	}
-
-	set_transient( 'child_igdb_access_token', $access_token, max( HOUR_IN_SECONDS, $expires_in - 300 ) );
-
-	return $access_token;
-}
-
-/**
- * Build an IGDB image URL for a cover image ID.
- */
-function child_build_igdb_cover_url( string $image_id, string $size = 'cover_big' ): string {
-	$image_id = preg_replace( '/[^a-zA-Z0-9_-]/', '', $image_id );
-	$size     = preg_replace( '/[^a-zA-Z0-9_]/', '', $size );
-
-	if ( '' === $image_id ) {
-		return '';
-	}
-
-	return esc_url_raw( sprintf( 'https://images.igdb.com/igdb/image/upload/t_%s/%s.jpg', $size ?: 'cover_big', $image_id ) );
-}
-
-/**
- * Fetch a portrait cover from IGDB by game title.
- */
-function child_find_igdb_cover_for_game( string $title ): array {
-	$title        = trim( $title );
-	$client_id    = child_get_igdb_client_id();
-	$access_token = child_get_igdb_access_token();
-
-	if ( '' === $title || '' === $client_id || '' === $access_token ) {
+function child_request_steamgriddb_api( string $path ): array {
+	$api_key = child_get_steamgriddb_api_key();
+	if ( '' === $api_key ) {
 		return [];
 	}
 
-	$response = wp_safe_remote_post(
-		'https://api.igdb.com/v4/games',
+	$response = wp_safe_remote_get(
+		'https://www.steamgriddb.com/api/v2/' . ltrim( $path, '/' ),
 		[
 			'timeout' => 10,
 			'headers' => [
 				'Accept'        => 'application/json',
-				'Authorization' => 'Bearer ' . $access_token,
-				'Client-ID'     => $client_id,
+				'Authorization' => 'Bearer ' . $api_key,
 			],
-			'body'    => sprintf(
-				'search "%s"; fields cover.image_id,cover.width,cover.height; where cover != null; limit 1;',
-				addcslashes( $title, '\\"' )
-			),
 		]
 	);
 
@@ -135,17 +55,64 @@ function child_find_igdb_cover_for_game( string $title ): array {
 		return [];
 	}
 
-	$data  = json_decode( wp_remote_retrieve_body( $response ), true );
-	$cover = is_array( $data[0]['cover'] ?? null ) ? $data[0]['cover'] : [];
+	$data = json_decode( wp_remote_retrieve_body( $response ), true );
 
-	if ( empty( $cover['image_id'] ) ) {
+	return is_array( $data['data'] ?? null ) ? $data['data'] : [];
+}
+
+/**
+ * Pick the best portrait SteamGridDB grid image from an API response.
+ */
+function child_pick_steamgriddb_portrait_grid( array $grids ): array {
+	foreach ( $grids as $grid ) {
+		if ( ! is_array( $grid ) || empty( $grid['url'] ) ) {
+			continue;
+		}
+
+		$width  = absint( $grid['width'] ?? 0 );
+		$height = absint( $grid['height'] ?? 0 );
+
+		if ( $width > 0 && $height > 0 && $height <= $width ) {
+			continue;
+		}
+
+		return [
+			'cover_url'    => esc_url_raw( (string) $grid['url'] ),
+			'cover_format' => 'portrait',
+		];
+	}
+
+	return [];
+}
+
+/**
+ * Fetch a portrait cover from SteamGridDB by game title.
+ */
+function child_find_steamgriddb_cover_for_game( string $title ): array {
+	$title = trim( $title );
+	if ( '' === $title || '' === child_get_steamgriddb_api_key() ) {
 		return [];
 	}
 
-	return [
-		'cover_url'    => child_build_igdb_cover_url( (string) $cover['image_id'], 'cover_big' ),
-		'cover_format' => 'portrait',
-	];
+	$games = child_request_steamgriddb_api( 'search/autocomplete/' . rawurlencode( $title ) );
+	if ( [] === $games || empty( $games[0]['id'] ) ) {
+		return [];
+	}
+
+	$game_id = absint( $games[0]['id'] );
+	if ( 0 === $game_id ) {
+		return [];
+	}
+
+	$grids = child_request_steamgriddb_api( 'grids/game/' . $game_id . '?dimensions=600x900' );
+	$cover = child_pick_steamgriddb_portrait_grid( $grids );
+	if ( [] !== $cover ) {
+		return $cover;
+	}
+
+	$grids = child_request_steamgriddb_api( 'grids/game/' . $game_id );
+
+	return child_pick_steamgriddb_portrait_grid( $grids );
 }
 
 /**
@@ -196,17 +163,7 @@ function child_register_videogame_recommendation_settings(): void {
 
 	register_setting(
 		'child_videogame_recommendation',
-		'child_igdb_client_id',
-		[
-			'type'              => 'string',
-			'sanitize_callback' => 'sanitize_text_field',
-			'default'           => '',
-		]
-	);
-
-	register_setting(
-		'child_videogame_recommendation',
-		'child_igdb_client_secret',
+		'child_steamgriddb_api_key',
 		[
 			'type'              => 'string',
 			'sanitize_callback' => 'sanitize_text_field',
@@ -230,17 +187,9 @@ function child_register_videogame_recommendation_settings(): void {
 	);
 
 	add_settings_field(
-		'child_igdb_client_id',
-		__( 'IGDB Client ID', 'child' ),
-		'child_render_igdb_client_id_field',
-		'child-videogame-recommendation',
-		'child_videogame_recommendation_section'
-	);
-
-	add_settings_field(
-		'child_igdb_client_secret',
-		__( 'IGDB Client Secret', 'child' ),
-		'child_render_igdb_client_secret_field',
+		'child_steamgriddb_api_key',
+		__( 'SteamGridDB API Key', 'child' ),
+		'child_render_steamgriddb_api_field',
 		'child-videogame-recommendation',
 		'child_videogame_recommendation_section'
 	);
@@ -253,9 +202,10 @@ add_action( 'admin_init', 'child_register_videogame_recommendation_settings' );
 function child_render_videogame_recommendation_section_description(): void {
 	echo '<p>' . wp_kses_post(
 		sprintf(
-			/* translators: %s: URL to RAWG API docs */
-			__( 'To use the Videogame Recommendation block, you need a free API key from RAWG. Add optional IGDB credentials to enrich results with portrait game covers. Get your RAWG API key at %s.', 'child' ),
-			'<a href="https://rawg.io/apidocs" target="_blank" rel="noopener noreferrer">rawg.io/apidocs</a>'
+			/* translators: 1: URL to RAWG API docs. 2: URL to SteamGridDB API docs. */
+			__( 'To use the Videogame Recommendation block, you need a free API key from RAWG. Add an optional SteamGridDB API key to enrich results with portrait game covers. Get your RAWG API key at %1$s and your SteamGridDB API key at %2$s.', 'child' ),
+			'<a href="https://rawg.io/apidocs" target="_blank" rel="noopener noreferrer">rawg.io/apidocs</a>',
+			'<a href="https://www.steamgriddb.com/api/v2" target="_blank" rel="noopener noreferrer">steamgriddb.com/api/v2</a>'
 		)
 	) . '</p>';
 }
@@ -278,37 +228,20 @@ function child_render_videogame_recommendation_api_field(): void {
 }
 
 /**
- * Render IGDB client ID input.
+ * Render SteamGridDB key input.
  */
-function child_render_igdb_client_id_field(): void {
-	$value        = (string) get_option( 'child_igdb_client_id', '' );
-	$has_constant = defined( 'IGDB_CLIENT_ID' ) && ! empty( IGDB_CLIENT_ID );
+function child_render_steamgriddb_api_field(): void {
+	$value        = (string) get_option( 'child_steamgriddb_api_key', '' );
+	$has_constant = defined( 'STEAMGRIDDB_API_KEY' ) && ! empty( STEAMGRIDDB_API_KEY );
 
-	echo '<input type="text" id="child_igdb_client_id" name="child_igdb_client_id" value="' . esc_attr( $value ) . '" class="regular-text" placeholder="' . esc_attr__( 'Enter your IGDB Client ID', 'child' ) . '" />';
+	echo '<input type="password" id="child_steamgriddb_api_key" name="child_steamgriddb_api_key" value="' . esc_attr( $value ) . '" class="regular-text" placeholder="' . esc_attr__( 'Enter your SteamGridDB API key', 'child' ) . '" autocomplete="new-password" />';
 
 	if ( $has_constant && '' === $value ) {
-		echo '<p class="description">' . esc_html__( 'Currently using IGDB Client ID from wp-config.php. Enter a value here to override it.', 'child' ) . '</p>';
+		echo '<p class="description">' . esc_html__( 'Currently using SteamGridDB API key from wp-config.php. Enter a key here to override it.', 'child' ) . '</p>';
 		return;
 	}
 
-	echo '<p class="description">' . esc_html__( 'Optional: Used to fetch portrait videogame covers from IGDB.', 'child' ) . '</p>';
-}
-
-/**
- * Render IGDB client secret input.
- */
-function child_render_igdb_client_secret_field(): void {
-	$value        = (string) get_option( 'child_igdb_client_secret', '' );
-	$has_constant = defined( 'IGDB_CLIENT_SECRET' ) && ! empty( IGDB_CLIENT_SECRET );
-
-	echo '<input type="password" id="child_igdb_client_secret" name="child_igdb_client_secret" value="' . esc_attr( $value ) . '" class="regular-text" placeholder="' . esc_attr__( 'Enter your IGDB Client Secret', 'child' ) . '" autocomplete="new-password" />';
-
-	if ( $has_constant && '' === $value ) {
-		echo '<p class="description">' . esc_html__( 'Currently using IGDB Client Secret from wp-config.php. Enter a value here to override it.', 'child' ) . '</p>';
-		return;
-	}
-
-	echo '<p class="description">' . esc_html__( 'Optional: Stored in the database and only used server-side for IGDB access tokens.', 'child' ) . '</p>';
+	echo '<p class="description">' . esc_html__( 'Optional: Used server-side to fetch portrait videogame covers from SteamGridDB.', 'child' ) . '</p>';
 }
 
 /**
@@ -363,9 +296,9 @@ function child_handle_rawg_search_ajax(): void {
 
 	$games = array_map(
 		static function( array $game ): array {
-			$igdb_cover  = child_find_igdb_cover_for_game( (string) ( $game['name'] ?? '' ) );
-			$cover_url   = (string) ( $igdb_cover['cover_url'] ?? '' );
-			$cover_format = (string) ( $igdb_cover['cover_format'] ?? '' );
+			$steamgriddb_cover  = child_find_steamgriddb_cover_for_game( (string) ( $game['name'] ?? '' ) );
+			$cover_url    = (string) ( $steamgriddb_cover['cover_url'] ?? '' );
+			$cover_format = (string) ( $steamgriddb_cover['cover_format'] ?? '' );
 
 			return [
 				'id'               => $game['id'] ?? 0,


### PR DESCRIPTION
### Motivation

- Enable optional portrait videogame box-art to enrich RAWG search results and allow blocks to render either `portrait` or `landscape` covers. 
- Improve the media cover grid filter UI to be horizontally scrollable and more accessible on small viewports.

### Description

- Add `coverFormat` attribute to the videogame block (`block.json`) and thread it through editor code (`index.js`) and preview component (`GamePreview.js`) so the media container uses `child-game-card__media--portrait` or `--landscape` classes. 
- Update `utils.js` to prefer an optional `cover_url` from IGDB and set `coverFormat` heuristically (`portrait` when `cover_url` present, otherwise `landscape`).
- Extend README to document optional IGDB integration and how credentials may be supplied via settings or constants.
- Implement server-side IGDB support in `inc/videogame-recommendation.php` including settings fields for `child_igdb_client_id` and `child_igdb_client_secret`, token retrieval (`child_get_igdb_access_token`), cover lookup (`child_find_igdb_cover_for_game`), and URL builder (`child_build_igdb_cover_url`), and include IGDB results in the RAWG AJAX response.
- Normalize videogame cover format in `inc/media-cover-grid-normalizers.php` so stored items can be `portrait` or `landscape` and render accordingly in the media grid item payload.
- Adjust media filter markup in `blocks/media-cover-grid/render.php` to wrap filters in a scrollable filter list and tweak ARIA/role attributes for the control group.
- Update CSS in `blocks/media-cover-grid/style.css` and `blocks/videogame-recommendation/style.css` to support the new filter list layout, hide scrollbars, and add portrait/landscape media sizing styles.

### Testing

- Built JavaScript assets with `npm run build` and ran the linter with `npm run lint`, both completed successfully. 
- Ran frontend unit tests with `npm test` which passed against the modified components and utilities.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5222b817788325b2e9414a050a8a88)